### PR TITLE
Support multiple accounts and feeds

### DIFF
--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to Mastodon.
 type: application
 version: 0.1.0
-appVersion: "0.1.0-mango-r7"
+appVersion: "0.1.0-multiple-r2"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to Mastodon.
 type: application
 version: 0.1.0
-appVersion: "0.1.0-multiple-r2"
+appVersion: "0.1.0-preview-r2"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to Mastodon.
 type: application
 version: 0.1.0
-appVersion: "0.1.0-preview-r4"
+appVersion: "0.1.0-preview-r5"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to Mastodon.
 type: application
 version: 0.1.0
-appVersion: "0.1.0-preview-r2"
+appVersion: "0.1.0-preview-r4"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/README.md
+++ b/mika/rizz/README.md
@@ -101,26 +101,23 @@ helm uninstall $release_name --namespace $namespace --wait
 | image.rizz.tag | string | `""` | The tag that specifies the version of the Rizz container image used. Default: `Chart appVersion`. |
 | imagePullSecrets | list | `[]` | Credentials used to securely authenticate and authorise the pulling of container images from private registries. |
 | replicaCount | string | `""` | The desired number of running replicas for Rizz. Default: `"1"`. |
-| resources.scheduler.limits.cpu | string | `"20m"` | The maximum amount of CPU resources allowed for Scheduler. |
-| resources.scheduler.limits.memory | string | `"200Mi"` | The maximum amount of memory allowed for Scheduler. |
-| resources.scheduler.requests.cpu | string | `"10m"` | The minimum amount of CPU resources required by Scheduler. |
-| resources.scheduler.requests.memory | string | `"100Mi"` | The minimum amount of memory required by Scheduler. |
 | resources.rizz.limits.cpu | string | `"50m"` | The maximum amount of CPU resources allowed for Rizz. |
 | resources.rizz.limits.memory | string | `"120Mi"` | The maximum amount of memory allowed for Rizz. |
 | resources.rizz.requests.cpu | string | `"30m"` | The minimum amount of CPU resources required by Rizz. |
 | resources.rizz.requests.memory | string | `"60Mi"` | The minimum amount of memory required by Rizz. |
+| resources.scheduler.limits.cpu | string | `"20m"` | The maximum amount of CPU resources allowed for Scheduler. |
+| resources.scheduler.limits.memory | string | `"200Mi"` | The maximum amount of memory allowed for Scheduler. |
+| resources.scheduler.requests.cpu | string | `"10m"` | The minimum amount of CPU resources required by Scheduler. |
+| resources.scheduler.requests.memory | string | `"100Mi"` | The minimum amount of memory required by Scheduler. |
 | rizz.debug | bool | `false` | Specifies whether Rizz should run in debug mode. Default: `false`. |
 | rizz.domain | string | `""` | The domain name of the Rizz service. Default: `"localhost"`. |
-| rizz.mastodon.api | string | `""` | API endpoint or URL for the Mastodon instance of the Rizz bot. |
-| rizz.mastodon.bot | string | `""` | The username or user account for the Mastodon instance of the Rizz bot. |
-| rizz.mastodon.token | string | `""` | A secure token required to authenticate the Rizz service with the Mastodon instance's API. |
+| rizz.feed | list | `[]` | Rizz feed configurations. |
+| rizz.mastodon | list | `[]` | Rizz Mastodon configurations. |
 | rizz.organic | bool | `true` | Specifies whether to enable posting in organic numbers. Default: `true`. |
 | rizz.persistence.enabled | bool | `false` | Specifies whether Rizz should persist its storage. |
 | rizz.persistence.logs.storage | string | `""` | The amount of persistent storage allocated for Rizz logs. Default: `"20Mi"`. |
 | rizz.persistence.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the Rizz storage. Default: `"longhorn"`. |
 | rizz.post_limit | string | `""` | The limit number of posts to be scheduled for posting per run. Default: `"3"`. |
-| rizz.rss.feed | string | `""` | The URL of the RSS feed to be tracked by Rizz. |
-| rizz.rss.pubdate_format | string | `""` | The publishing date format of the RSS feed entry. Default: `"%a, %d %b %Y %H:%M:%S %z"`. |
 | rizz.scheduler.apscheduler | bool | `true` | Specifies whether APScheduler should be used by Rizz as the task scheduler. |
 | rizz.scheduler.celery | bool | `false` | Specifies whether Celery should be used by Rizz as the task scheduler. |
 | rizz.scheduler.schedule.clean_data | string | `""` | The hours at which the task scheduler cleans up the database. Default: `"0"`. |

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -21,10 +21,10 @@ Mastodon /base/lib/accounts.json template
             "fields": [
                 {{- $fields := $account.fields }}
                 {{- range $i, $field := $fields }}
-                {
-                    "name": {{ $field.name | toString | quote }},
-                    "value": {{ $field.value | toString | quote }}
-                }{{ if ne $i (sub (len $fields) 1) }},{{ end }}
+                [
+                    {{ $field.name | toString | quote }},
+                    {{ $field.value | toString | quote }}
+                ]{{ if ne $i (sub (len $fields) 1) }},{{ end }}
                 {{- end }}
             ],
             "is_locked": {{ $account.locked | default "false" | toString }},

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -7,11 +7,11 @@ Mastodon /base/lib/accounts.json template
         {{- $accounts := .Values.rizz.mastodon }}
         {{- range $index, $account := $accounts }}
         {
-            "id": {{ $account.id | toString | quote }},
+            "uid": {{ $account.id | toString | quote }},
             "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
             "api_base_url": {{ $account.api | toString | quote }},
-            "bot": {{ $account.bot | default "true" | toString }},
-            "discoverable": {{ $account.discoverable | default "true" | toString }},
+            "is_bot": {{ $account.bot | default "true" | toString }},
+            "is_discoverable": {{ $account.discoverable | default "true" | toString }},
             {{- if $account.display_name }}
             "display_name": {{ $account.display_name | toString | quote }}
             {{- else }}
@@ -26,7 +26,7 @@ Mastodon /base/lib/accounts.json template
                 }{{ if ne $i (sub (len $fields) 1) }},{{ end }}
                 {{- end }}
             ],
-            "locked": {{ $account.locked | default "false" | toString }},
+            "is_locked": {{ $account.locked | default "false" | toString }},
             {{- if $account.note }}
             "note": {{ $account.note | toString | quote }}
             {{- else }}

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -3,7 +3,7 @@ Mastodon /base/lib/accounts.json template
 */}}
 {{- define "rizz.accounts-json" -}}
 {
-    "feeds": [
+    "accounts": [
         {{- $accounts := .Values.rizz.mastodon }}
         {{- range $index, $account := $accounts }}
         {

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -6,9 +6,10 @@ Mastodon /base/lib/accounts.json template
     "accounts": [
         {{- $accounts := .Values.rizz.mastodon }}
         {{- range $index, $account := $accounts }}
+        {{- $normalised_api := $account.api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
         {
             "uid": {{ $account.id | toString | quote }},
-            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s-%s.secret" $account.id $normalised_api | toString | replace " " "" | quote }},
             "api_base_url": {{ $account.api | toString | quote }},
             "is_bot": {{ $account.bot | default "true" | toString }},
             "is_discoverable": {{ $account.discoverable | default "true" | toString }},

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -1,0 +1,39 @@
+{{/*
+Mastodon /base/lib/accounts.json template
+*/}}
+{{- define "rizz.accounts-json" -}}
+{
+    "feeds": [
+        {{- $accounts := .Values.rizz.mastodon }}
+        {{- range $index, $account := $accounts }}
+        {
+            "id": {{ $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "api_base_url": {{ $account.api | toString | quote }},
+            "bot": {{ $account.bot | default "true" | toString }},
+            "discoverable": {{ $account.discoverable | default "true" | toString }},
+            {{- if $account.display_name }}
+            "display_name": {{ $account.display_name | toString | quote }}
+            {{- else }}
+            "display_name": {{ $account.display_name | default "null" | toString }}
+            {{- end }},
+            "fields": [
+                {{- $fields := $account.fields }}
+                {{- range $i, $field := $fields }}
+                {
+                    "name": {{ $field.name | toString | quote }},
+                    "value": {{ $field.value | toString | quote }}
+                }{{ if ne $i (sub (len $fields) 1) }},{{ end }}
+                {{- end }}
+            ],
+            "locked": {{ $account.locked | default "false" | toString }},
+            {{- if $account.note }}
+            "note": {{ $account.note | toString | quote }}
+            {{- else }}
+            "note": {{ $account.note | default "null" | toString }}
+            {{- end }}
+        }{{ if ne $index (sub (len $accounts) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/rizz/templates/accounts.json.tpl
+++ b/mika/rizz/templates/accounts.json.tpl
@@ -12,6 +12,7 @@ Mastodon /base/lib/accounts.json template
             "api_base_url": {{ $account.api | toString | quote }},
             "is_bot": {{ $account.bot | default "true" | toString }},
             "is_discoverable": {{ $account.discoverable | default "true" | toString }},
+            "is_enabled": {{ $account.enabled | default "true" | toString }},
             {{- if $account.display_name }}
             "display_name": {{ $account.display_name | toString | quote }}
             {{- else }}

--- a/mika/rizz/templates/configmap.yaml
+++ b/mika/rizz/templates/configmap.yaml
@@ -38,6 +38,16 @@ metadata:
 data:
   site-config.conf: |-
     {{- include "rizz.site-config-conf" . | replace "DOMAIN" $domain | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-rizz-rss-config
+  labels:
+    {{- include "rizz.labels" . | nindent 4 }}
+data:
+  feeds.json: |-
+    {{- include "rizz.feeds-json" . | toString | nindent 4 }}
 {{- if $apscheduler }}
 ---
 apiVersion: v1

--- a/mika/rizz/templates/configmap.yaml
+++ b/mika/rizz/templates/configmap.yaml
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-rizz-rss-config
+  name: {{ .Release.Name }}-rizz-feed-config
   labels:
     {{- include "rizz.labels" . | nindent 4 }}
 data:

--- a/mika/rizz/templates/configmap.yaml
+++ b/mika/rizz/templates/configmap.yaml
@@ -1,12 +1,8 @@
 {{- $debug := .Values.rizz.debug | default "false" | toString | quote }}
-{{- $api := .Values.rizz.mastodon.api | toString | quote }}
-{{- $bot := .Values.rizz.mastodon.bot | toString | quote }}
 {{- $scheduler_timezone := .Values.rizz.scheduler.timezone | default "Asia/Kuala_Lumpur" | toString | quote }}
 {{- $visibility := .Values.rizz.visibility | default "public" | toString | quote }}
 {{- $organic := .Values.rizz.organic | default "true" | toString | quote }}
 {{- $post_limit := .Values.rizz.post_limit | default "3" | toString | quote }}
-{{- $feed := .Values.rizz.rss.feed | toString | quote }}
-{{- $pubdate_format := .Values.rizz.rss.pubdate_format | default "%a, %d %b %Y %H:%M:%S %z" | toString | quote }}
 {{- $clean_data := .Values.rizz.scheduler.schedule.clean_data | default "0" | toString | quote }}
 {{- $post_scheduler := .Values.rizz.scheduler.schedule.post_scheduler | default "8-23/3" | toString | quote }}
 {{- $update_data := .Values.rizz.scheduler.schedule.update_data | default "7-22/3" | toString | quote }}
@@ -22,13 +18,9 @@ metadata:
     {{- include "rizz.labels" . | nindent 4 }}
 data:
   DEBUG: {{ $debug }}
-  API_BASE_URL: {{ $api }}
-  BOT_ID: {{ $bot }}
   DEFAULT_VISIBILITY: {{ $visibility }}
   ORGANIC_POSTS: {{ $organic }}
   POST_LIMIT: {{ $post_limit }}
-  RSS_FEED_URL: {{ $feed }}
-  RSS_PUBDATE_FORMAT: {{ $pubdate_format }}
   {{- if $celery }}
   CELERY_BROKER: {{ $redis_service }}
   CELERY_BACKEND: {{ $redis_service }}

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -59,6 +59,10 @@ spec:
               mountPath: /base/lib/feeds.json
               subPath: feeds.json
               readOnly: true
+            - name: {{ .Release.Name }}-rizz-mastodon-config
+              mountPath: /base/lib/accounts.json
+              subPath: accounts.json
+              readOnly: true
             {{- if $celery }}
             - name: {{ .Release.Name }}-rizz-default-celery-config
               mountPath: /etc/default/celeryd
@@ -109,6 +113,10 @@ spec:
               mountPath: /base/lib/feeds.json
               subPath: feeds.json
               readOnly: true
+            - name: {{ .Release.Name }}-rizz-mastodon-config
+              mountPath: /base/lib/accounts.json
+              subPath: accounts.json
+              readOnly: true
             - name: {{ .Release.Name }}-rizz-apscheduler-config
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
@@ -146,6 +154,9 @@ spec:
         - name: {{ .Release.Name }}-rizz-rss-config
           configMap:
             name: {{ .Release.Name }}-rizz-rss-config
+        - name: {{ .Release.Name }}-rizz-mastodon-config
+          secret:
+            secretName: {{ .Release.Name }}-rizz-mastodon-config
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-rizz-apscheduler-config
           configMap:

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
+            - name: {{ .Release.Name }}-rizz-rss-config
+              mountPath: /base/lib/feeds.json
+              subPath: feeds.json
+              readOnly: true
             {{- if $celery }}
             - name: {{ .Release.Name }}-rizz-default-celery-config
               mountPath: /etc/default/celeryd
@@ -101,6 +105,10 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-rizz-secret
           volumeMounts:
+            - name: {{ .Release.Name }}-rizz-rss-config
+              mountPath: /base/lib/feeds.json
+              subPath: feeds.json
+              readOnly: true
             - name: {{ .Release.Name }}-rizz-apscheduler-config
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
@@ -135,6 +143,9 @@ spec:
         - name: {{ .Release.Name }}-rizz-site-config
           configMap:
             name: {{ .Release.Name }}-rizz-site-config
+        - name: {{ .Release.Name }}-rizz-rss-config
+          configMap:
+            name: {{ .Release.Name }}-rizz-rss-config
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-rizz-apscheduler-config
           configMap:

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -84,9 +84,10 @@ spec:
               subPath: init.py
             {{- end }}
             {{- range .Values.rizz.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-rizz-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -127,9 +128,10 @@ spec:
               mountPath: /base/base/tasks.py
               subPath: tasks.py
             {{- range .Values.rizz.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-rizz-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -207,8 +209,9 @@ spec:
             secretName: {{ .Release.Name }}-rizz-token-secret
             items:
               {{- range .Values.rizz.mastodon }}
-              - key: {{ printf "%s.secret" .id | toString }}
-                path: {{ printf "%s.secret" .id | toString }}
+              {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+              - key: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+                path: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               {{- end }}
         {{- end }}
         {{- if $persistence }}

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
-            - name: {{ .Release.Name }}-rizz-rss-config
+            - name: {{ .Release.Name }}-rizz-feed-config
               mountPath: /base/data/feeds.json
               subPath: feeds.json
               readOnly: true
@@ -109,7 +109,7 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-rizz-secret
           volumeMounts:
-            - name: {{ .Release.Name }}-rizz-rss-config
+            - name: {{ .Release.Name }}-rizz-feed-config
               mountPath: /base/data/feeds.json
               subPath: feeds.json
               readOnly: true
@@ -151,9 +151,9 @@ spec:
         - name: {{ .Release.Name }}-rizz-site-config
           configMap:
             name: {{ .Release.Name }}-rizz-site-config
-        - name: {{ .Release.Name }}-rizz-rss-config
+        - name: {{ .Release.Name }}-rizz-feed-config
           configMap:
-            name: {{ .Release.Name }}-rizz-rss-config
+            name: {{ .Release.Name }}-rizz-feed-config
         - name: {{ .Release.Name }}-rizz-mastodon-config
           secret:
             secretName: {{ .Release.Name }}-rizz-mastodon-config

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}
 {{- $rizz_registry := .Values.image.rizz.registry | default "ghcr.io" | toString }}
 {{- $rizz_repository := .Values.image.rizz.repository | default "irfanhakim-as/rizz" | toString }}
@@ -74,10 +75,12 @@ spec:
               mountPath: /base/base/__init__.py
               subPath: init.py
             {{- end }}
-            - name: {{ .Release.Name }}-rizz-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.rizz.mastodon }}
+            - name: {{ $release_name }}-rizz-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-rizz-logs
               mountPath: /var/log/apache2
@@ -107,10 +110,12 @@ spec:
             - name: {{ .Release.Name }}-rizz-scheduler-config
               mountPath: /base/base/tasks.py
               subPath: tasks.py
-            - name: {{ .Release.Name }}-rizz-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.rizz.mastodon }}
+            - name: {{ $release_name }}-rizz-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-rizz-logs
               mountPath: /var/log/apache2
@@ -174,9 +179,16 @@ spec:
               - key: tasks.py
                 path: tasks.py
         {{- end }}
+        {{- if .Values.rizz.mastodon }}
         - name: {{ .Release.Name }}-rizz-token-secret
           secret:
             secretName: {{ .Release.Name }}-rizz-token-secret
+            items:
+              {{- range .Values.rizz.mastodon }}
+              - key: {{ printf "%s.secret" .id | toString }}
+                path: {{ printf "%s.secret" .id | toString }}
+              {{- end }}
+        {{- end }}
         {{- if $persistence }}
         - name: {{ .Release.Name }}-rizz-logs
           persistentVolumeClaim:

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -56,11 +56,11 @@ spec:
               subPath: site-config.conf
               readOnly: true
             - name: {{ .Release.Name }}-rizz-rss-config
-              mountPath: /base/lib/feeds.json
+              mountPath: /base/data/feeds.json
               subPath: feeds.json
               readOnly: true
             - name: {{ .Release.Name }}-rizz-mastodon-config
-              mountPath: /base/lib/accounts.json
+              mountPath: /base/data/accounts.json
               subPath: accounts.json
               readOnly: true
             {{- if $celery }}
@@ -110,11 +110,11 @@ spec:
                 name: {{ .Release.Name }}-rizz-secret
           volumeMounts:
             - name: {{ .Release.Name }}-rizz-rss-config
-              mountPath: /base/lib/feeds.json
+              mountPath: /base/data/feeds.json
               subPath: feeds.json
               readOnly: true
             - name: {{ .Release.Name }}-rizz-mastodon-config
-              mountPath: /base/lib/accounts.json
+              mountPath: /base/data/accounts.json
               subPath: accounts.json
               readOnly: true
             - name: {{ .Release.Name }}-rizz-apscheduler-config

--- a/mika/rizz/templates/feeds.json.tpl
+++ b/mika/rizz/templates/feeds.json.tpl
@@ -1,0 +1,17 @@
+{{/*
+Mastodon /base/lib/feeds.json template
+*/}}
+{{- define "rizz.feeds-json" -}}
+{
+    "feeds": [
+        {{- $feeds := .Values.rizz.rss }}
+        {{- range $index, $feed := $feeds }}
+        {
+            "id": {{ $feed.id | toString | quote }},
+            "url": {{ $feed.feed | toString | quote }},
+            "date_format": {{ $feed.pubdate_format | default "%a, %d %b %Y %H:%M:%S %z" | toString | quote }}
+        }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/rizz/templates/feeds.json.tpl
+++ b/mika/rizz/templates/feeds.json.tpl
@@ -9,6 +9,7 @@ Mastodon /base/lib/feeds.json template
         {
             "uid": {{ $feed.id | toString | quote }},
             "endpoint": {{ $feed.feed | toString | quote }},
+            "is_enabled": {{ $feed.enabled | default "true" | toString }},
             "date_format": {{ $feed.pubdate_format | default "%a, %d %b %Y %H:%M:%S %z" | toString | quote }}
         }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}
         {{- end }}

--- a/mika/rizz/templates/feeds.json.tpl
+++ b/mika/rizz/templates/feeds.json.tpl
@@ -4,11 +4,11 @@ Mastodon /base/lib/feeds.json template
 {{- define "rizz.feeds-json" -}}
 {
     "feeds": [
-        {{- $feeds := .Values.rizz.rss }}
+        {{- $feeds := .Values.rizz.feed }}
         {{- range $index, $feed := $feeds }}
         {
             "uid": {{ $feed.id | toString | quote }},
-            "endpoint": {{ $feed.feed | toString | quote }},
+            "endpoint": {{ $feed.endpoint | toString | quote }},
             "is_enabled": {{ $feed.enabled | default "true" | toString }},
             "date_format": {{ $feed.pubdate_format | default "%a, %d %b %Y %H:%M:%S %z" | toString | quote }}
         }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}

--- a/mika/rizz/templates/feeds.json.tpl
+++ b/mika/rizz/templates/feeds.json.tpl
@@ -7,8 +7,8 @@ Mastodon /base/lib/feeds.json template
         {{- $feeds := .Values.rizz.rss }}
         {{- range $index, $feed := $feeds }}
         {
-            "id": {{ $feed.id | toString | quote }},
-            "url": {{ $feed.feed | toString | quote }},
+            "uid": {{ $feed.id | toString | quote }},
+            "endpoint": {{ $feed.feed | toString | quote }},
             "date_format": {{ $feed.pubdate_format | default "%a, %d %b %Y %H:%M:%S %z" | toString | quote }}
         }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}
         {{- end }}

--- a/mika/rizz/templates/secret.yaml
+++ b/mika/rizz/templates/secret.yaml
@@ -20,6 +20,7 @@ data:
   DB_PASS: {{ $db_password }}
   DB_HOST: {{ $db_host }}
   DB_PORT: {{ $db_port }}
+{{- if .Values.rizz.mastodon }}
 ---
 apiVersion: v1
 kind: Secret
@@ -29,5 +30,8 @@ metadata:
     {{- include "rizz.labels" . | nindent 4 }}
 type: Opaque
 data:
-  mastodon.secret: |-
-    {{ $token | nindent 4 }}
+  {{- range .Values.rizz.mastodon }}
+  {{ printf "%s.secret" .id | toString }}: |-
+    {{ .token | toString | b64enc | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/mika/rizz/templates/secret.yaml
+++ b/mika/rizz/templates/secret.yaml
@@ -5,7 +5,6 @@
 {{- $db_password := .Values.db.password | toString | b64enc }}
 {{- $db_host := .Values.db.host | toString | b64enc }}
 {{- $db_port := .Values.db.port | default "5432" | toString | b64enc }}
-{{- $token := .Values.rizz.mastodon.token | toString | b64enc }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/mika/rizz/templates/secret.yaml
+++ b/mika/rizz/templates/secret.yaml
@@ -42,7 +42,8 @@ metadata:
 type: Opaque
 data:
   {{- range .Values.rizz.mastodon }}
-  {{ printf "%s.secret" .id | toString }}: |-
+  {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+  {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}: |-
     {{ .token | toString | b64enc | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/mika/rizz/templates/secret.yaml
+++ b/mika/rizz/templates/secret.yaml
@@ -20,6 +20,17 @@ data:
   DB_PASS: {{ $db_password }}
   DB_HOST: {{ $db_host }}
   DB_PORT: {{ $db_port }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-rizz-mastodon-config
+  labels:
+    {{- include "rizz.labels" . | nindent 4 }}
+type: Opaque
+data:
+  accounts.json: |-
+    {{- include "rizz.accounts-json" . | toString | b64enc | nindent 4 }}
 {{- if .Values.rizz.mastodon }}
 ---
 apiVersion: v1

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -75,19 +75,57 @@ rizz:
   # visibility: "unlisted"
   visibility: ""
   # Rizz Mastodon configurations.
-  mastodon:
-    # API endpoint or URL for the Mastodon instance of the Rizz bot.
-    # Example:
-    # api: "https://botsin.space/"
-    api: ""
-    # The username or user account for the Mastodon instance of the Rizz bot.
-    # Example:
-    # bot: "rizz"
-    bot: ""
-    # A secure token required to authenticate the Rizz service with the Mastodon instance's API.
-    # Example:
-    # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
-    token: ""
+  # Example:
+  # mastodon:
+  #   # API endpoint or URL for the Mastodon instance of the Rizz bot.
+  #   # Example:
+  #   # api: "https://botsin.space/"
+  #   - api: ""
+  #   # The username or user account for the Mastodon instance of the Rizz bot.
+  #   # Example:
+  #   # id: "rizz"
+  #     id: ""
+  #   # A secure token required to authenticate the Rizz service with the Mastodon instance's API.
+  #   # Example:
+  #   # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
+  #     token: ""
+  #   # Specifies whether the Rizz bot should be marked as a bot.
+  #   # Default: true
+  #   # Example:
+  #   # bot: false
+  #     bot: ""
+  #   # Specifies whether the Rizz bot should appear in the user directory.
+  #   # Default: true
+  #   # Example:
+  #   # discoverable: false
+  #     discoverable: ""
+  #   # The display name of the Rizz bot.
+  #   # Default: null
+  #   # Example:
+  #   # display_name: "Rizz"
+  #     display_name: ""
+  #   # A list of up to four name-value pairs information to be displayed on the Rizz bot's profile.
+  #   # Default: []
+  #   # Example:
+  #   # fields:
+  #   #   - name: "Website 1"
+  #   #     value: "https://domain1.example.org"
+  #   #   - name: "Website 2"
+  #   #     value: "https://domain2.example.org"
+  #     fields:
+  #       - name: ""
+  #         value: ""
+  #   # Specifies whether the Rizz bot needs to manually approve follow requests.
+  #   # Default: false
+  #   # Example:
+  #   # locked: true
+  #     locked: ""
+  #   # The bio of the Rizz bot.
+  #   # Default: null
+  #   # Example:
+  #   # note: "This is the bio of the Rizz bot."
+  #     note: ""
+  mastodon: []
   # Rizz storage persistence configurations.
   persistence:
     # Specifies whether Rizz should persist its storage.
@@ -107,16 +145,22 @@ rizz:
       # storage: "1Gi"
       storage: ""
   # Rizz RSS configurations.
-  rss:
-    # The URL of the RSS feed to be tracked by Rizz.
-    # Example:
-    # feed: "https://www.reddit.com/r/programming/.rss"
-    feed: ""
-    # The publishing date format of the RSS feed entry.
-    # Default: "%a, %d %b %Y %H:%M:%S %z"
-    # Example:
-    # pubdate_format: "%a, %d %b %Y %H:%M:%S %Z"
-    pubdate_format: ""
+  # Example:
+  # rss:
+  #   # The URL of the RSS feed to be tracked by Rizz.
+  #   # Example:
+  #   # feed: "https://www.reddit.com/r/programming/.rss"
+  #   - feed: ""
+  #   # The publishing date format of the RSS feed entry.
+  #   # Default: "%a, %d %b %Y %H:%M:%S %z"
+  #   # Example:
+  #   # pubdate_format: "%a, %d %b %Y %H:%M:%S %Z"
+  #     pubdate_format: ""
+  #   # The unique identifier of the RSS feed entry.
+  #   # Example:
+  #   # id: "MyFeed"
+  #     id: ""
+  rss: []
   # Rizz scheduler configurations.
   scheduler:
     # Specifies whether APScheduler should be used by Rizz as the task scheduler.

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -149,13 +149,13 @@ rizz:
       # Example:
       # storage: "1Gi"
       storage: ""
-  # Rizz RSS configurations.
+  # Rizz feed configurations.
   # Example:
-  # rss:
+  # feed:
   #   # The URL of the RSS feed to be tracked by Rizz.
   #   # Example:
-  #   # feed: "https://www.reddit.com/r/programming/.rss"
-  #   - feed: ""
+  #   # endpoint: "https://www.reddit.com/r/programming/.rss"
+  #   - endpoint: ""
   #   # The publishing date format of the RSS feed entry.
   #   # Default: "%a, %d %b %Y %H:%M:%S %z"
   #   # Example:
@@ -170,7 +170,7 @@ rizz:
   #   # Example:
   #   # enabled: false
   #     enabled: ""
-  rss: []
+  feed: []
   # Rizz scheduler configurations.
   scheduler:
     # Specifies whether APScheduler should be used by Rizz as the task scheduler.

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -117,9 +117,7 @@ rizz:
   #   #     value: "https://domain1.example.org"
   #   #   - name: "Website 2"
   #   #     value: "https://domain2.example.org"
-  #     fields:
-  #       - name: ""
-  #         value: ""
+  #     fields: []
   #   # Specifies whether the Rizz bot needs to manually approve follow requests.
   #   # Default: false
   #   # Example:

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -79,7 +79,7 @@ rizz:
   # mastodon:
   #   # API endpoint or URL for the Mastodon instance of the Rizz bot.
   #   # Example:
-  #   # api: "https://botsin.space/"
+  #   # api: "https://botsin.space"
   #   - api: ""
   #   # The username or user account for the Mastodon instance of the Rizz bot.
   #   # Example:

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -99,6 +99,11 @@ rizz:
   #   # Example:
   #   # discoverable: false
   #     discoverable: ""
+  #   # Specifies whether the Rizz bot should be active.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
   #   # The display name of the Rizz bot.
   #   # Default: null
   #   # Example:
@@ -160,6 +165,11 @@ rizz:
   #   # Example:
   #   # id: "MyFeed"
   #     id: ""
+  #   # Specifies whether the RSS feed entry should be actively processed.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
   rss: []
   # Rizz scheduler configurations.
   scheduler:

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-mango-r2"
+appVersion: "0.2.0-multi-r1"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-preview-r2"
+appVersion: "0.2.0-preview-r3"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-multi-r1"
+appVersion: "0.2.0-preview-r2"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-preview-r3"
+appVersion: "0.2.0-preview-r4"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -111,7 +111,7 @@ helm uninstall $release_name --namespace $namespace --wait
 | resources.waktusolat.requests.memory | string | `"60Mi"` | The minimum amount of memory required by WaktuSolat. |
 | waktusolat.debug | bool | `false` | Specifies whether WaktuSolat should run in debug mode. Default: `false`. |
 | waktusolat.domain | string | `""` | The domain name of the WaktuSolat service. Default: `"localhost"`. |
-| waktusolat.location | string | `""` | The default location code used by WaktuSolat and its services. Default: `"wlp-0"`. |
+| waktusolat.location | list | `[]` | The code of locations WaktuSolat should fetch and update prayer times for. Default: `"wlp-0"`. |
 | waktusolat.mastodon.api | string | `""` | API endpoint or URL for the Mastodon instance of the WaktuSolat bot. |
 | waktusolat.mastodon.bot | string | `""` | The username or user account for the Mastodon instance of the WaktuSolat bot. |
 | waktusolat.mastodon.token | string | `""` | A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API. |

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -111,10 +111,9 @@ helm uninstall $release_name --namespace $namespace --wait
 | resources.waktusolat.requests.memory | string | `"60Mi"` | The minimum amount of memory required by WaktuSolat. |
 | waktusolat.debug | bool | `false` | Specifies whether WaktuSolat should run in debug mode. Default: `false`. |
 | waktusolat.domain | string | `""` | The domain name of the WaktuSolat service. Default: `"localhost"`. |
+| waktusolat.feed | list | `[]` | WaktuSolat feed configurations. |
 | waktusolat.location | list | `[]` | The code of locations WaktuSolat should fetch and update prayer times for. Default: `"wlp-0"`. |
-| waktusolat.mastodon.api | string | `""` | API endpoint or URL for the Mastodon instance of the WaktuSolat bot. |
-| waktusolat.mastodon.bot | string | `""` | The username or user account for the Mastodon instance of the WaktuSolat bot. |
-| waktusolat.mastodon.token | string | `""` | A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API. |
+| waktusolat.mastodon | list | `[]` | WaktuSolat Mastodon configurations. |
 | waktusolat.persistence.enabled | bool | `false` | Specifies whether WaktuSolat should persist its storage. |
 | waktusolat.persistence.logs.storage | string | `""` | The amount of persistent storage allocated for WaktuSolat logs. Default: `"20Mi"`. |
 | waktusolat.persistence.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the WaktuSolat storage. Default: `"longhorn"`. |

--- a/mika/waktusolat/templates/accounts.json.tpl
+++ b/mika/waktusolat/templates/accounts.json.tpl
@@ -1,0 +1,40 @@
+{{/*
+Mastodon /base/lib/accounts.json template
+*/}}
+{{- define "waktusolat.accounts-json" -}}
+{
+    "accounts": [
+        {{- $accounts := .Values.waktusolat.mastodon }}
+        {{- range $index, $account := $accounts }}
+        {
+            "uid": {{ $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "api_base_url": {{ $account.api | toString | quote }},
+            "is_bot": {{ $account.bot | default "true" | toString }},
+            "is_discoverable": {{ $account.discoverable | default "true" | toString }},
+            "is_enabled": {{ $account.enabled | default "true" | toString }},
+            {{- if $account.display_name }}
+            "display_name": {{ $account.display_name | toString | quote }}
+            {{- else }}
+            "display_name": {{ $account.display_name | default "null" | toString }}
+            {{- end }},
+            "fields": [
+                {{- $fields := $account.fields }}
+                {{- range $i, $field := $fields }}
+                [
+                    {{ $field.name | toString | quote }},
+                    {{ $field.value | toString | quote }}
+                ]{{ if ne $i (sub (len $fields) 1) }},{{ end }}
+                {{- end }}
+            ],
+            "is_locked": {{ $account.locked | default "false" | toString }},
+            {{- if $account.note }}
+            "note": {{ $account.note | toString | quote }}
+            {{- else }}
+            "note": {{ $account.note | default "null" | toString }}
+            {{- end }}
+        }{{ if ne $index (sub (len $accounts) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/waktusolat/templates/accounts.json.tpl
+++ b/mika/waktusolat/templates/accounts.json.tpl
@@ -6,9 +6,10 @@ Mastodon /base/lib/accounts.json template
     "accounts": [
         {{- $accounts := .Values.waktusolat.mastodon }}
         {{- range $index, $account := $accounts }}
+        {{- $normalised_api := $account.api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
         {
             "uid": {{ $account.id | toString | quote }},
-            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s-%s.secret" $account.id $normalised_api | toString | replace " " "" | quote }},
             "api_base_url": {{ $account.api | toString | quote }},
             "is_bot": {{ $account.bot | default "true" | toString }},
             "is_discoverable": {{ $account.discoverable | default "true" | toString }},

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -1,7 +1,5 @@
 {{- $debug := .Values.waktusolat.debug | default "false" | toString | quote }}
 {{- $location := .Values.waktusolat.location | default "wlp-0" | toString | quote }}
-{{- $api := .Values.waktusolat.mastodon.api | toString | quote }}
-{{- $bot := .Values.waktusolat.mastodon.bot | toString | quote }}
 {{- $visibility := .Values.waktusolat.visibility | default "public" | toString | quote }}
 {{- $post_limit := .Values.waktusolat.post_limit | default "0" | toString | quote }}
 {{- $scheduler_timezone := .Values.waktusolat.scheduler.timezone | default "Asia/Kuala_Lumpur" | toString | quote }}
@@ -22,8 +20,6 @@ metadata:
 data:
   DEBUG: {{ $debug }}
   LOCATION_CODE: {{ $location }}
-  API_BASE_URL: {{ $api }}
-  BOT_ID: {{ $bot }}
   DEFAULT_VISIBILITY: {{ $visibility }}
   POST_LIMIT: {{ $post_limit }}
   {{- if $celery }}
@@ -43,6 +39,16 @@ metadata:
 data:
   site-config.conf: |-
     {{- include "waktusolat.site-config-conf" . | replace "DOMAIN" $domain | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-waktusolat-feed-config
+  labels:
+    {{- include "waktusolat.labels" . | nindent 4 }}
+data:
+  feeds.json: |-
+    {{- include "waktusolat.feeds-json" . | toString | nindent 4 }}
 {{- if $apscheduler }}
 ---
 apiVersion: v1

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -39,6 +39,7 @@ metadata:
 data:
   site-config.conf: |-
     {{- include "waktusolat.site-config-conf" . | replace "DOMAIN" $domain | nindent 4 }}
+{{- if .Values.waktusolat.feed }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -49,6 +50,7 @@ metadata:
 data:
   feeds.json: |-
     {{- include "waktusolat.feeds-json" . | toString | nindent 4 }}
+{{- end }}
 {{- if $apscheduler }}
 ---
 apiVersion: v1

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $debug := .Values.waktusolat.debug | default "false" | toString | quote }}
-{{- $location := .Values.waktusolat.location | default "wlp-0" | toString | quote }}
+{{- $location := .Values.waktusolat.location | default "wlp-0" | join "," | toString | quote }}
 {{- $visibility := .Values.waktusolat.visibility | default "public" | toString | quote }}
 {{- $post_limit := .Values.waktusolat.post_limit | default "0" | toString | quote }}
 {{- $scheduler_timezone := .Values.waktusolat.scheduler.timezone | default "Asia/Kuala_Lumpur" | toString | quote }}

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "waktusolat.labels" . | nindent 4 }}
 data:
   DEBUG: {{ $debug }}
-  LOCATION_CODE: {{ $location }}
+  LOCATION_CODES: {{ $location }}
   DEFAULT_VISIBILITY: {{ $visibility }}
   POST_LIMIT: {{ $post_limit }}
   {{- if $celery }}

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -55,14 +55,16 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
-            - name: {{ .Release.Name }}-waktusolat-feed-config
-              mountPath: /base/data/feeds.json
-              subPath: feeds.json
-              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-mastodon-config
               mountPath: /base/data/accounts.json
               subPath: accounts.json
               readOnly: true
+            {{- if .Values.waktusolat.feed }}
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            {{- end }}
             {{- if $celery }}
             - name: {{ .Release.Name }}-waktusolat-default-celery-config
               mountPath: /etc/default/celeryd
@@ -109,10 +111,6 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-waktusolat-secret
           volumeMounts:
-            - name: {{ .Release.Name }}-waktusolat-feed-config
-              mountPath: /base/data/feeds.json
-              subPath: feeds.json
-              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-mastodon-config
               mountPath: /base/data/accounts.json
               subPath: accounts.json
@@ -130,6 +128,12 @@ spec:
             - name: {{ $release_name }}-waktusolat-token-secret
               mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
               subPath: {{ printf "%s.secret" .id | toString }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.waktusolat.feed }}
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -151,12 +155,14 @@ spec:
         - name: {{ .Release.Name }}-waktusolat-site-config
           configMap:
             name: {{ .Release.Name }}-waktusolat-site-config
-        - name: {{ .Release.Name }}-waktusolat-feed-config
-          configMap:
-            name: {{ .Release.Name }}-waktusolat-feed-config
         - name: {{ .Release.Name }}-waktusolat-mastodon-config
           secret:
             secretName: {{ .Release.Name }}-waktusolat-mastodon-config
+        {{- if .Values.waktusolat.feed }}
+        - name: {{ .Release.Name }}-waktusolat-feed-config
+          configMap:
+            name: {{ .Release.Name }}-waktusolat-feed-config
+        {{- end }}
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-waktusolat-apscheduler-config
           configMap:

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -86,9 +86,10 @@ spec:
               subPath: init.py
             {{- end }}
             {{- range .Values.waktusolat.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-waktusolat-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -125,9 +126,10 @@ spec:
               mountPath: /base/base/tasks.py
               subPath: tasks.py
             {{- range .Values.waktusolat.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-waktusolat-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if .Values.waktusolat.feed }}
@@ -213,8 +215,9 @@ spec:
             secretName: {{ .Release.Name }}-waktusolat-token-secret
             items:
               {{- range .Values.waktusolat.mastodon }}
-              - key: {{ printf "%s.secret" .id | toString }}
-                path: {{ printf "%s.secret" .id | toString }}
+              {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+              - key: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+                path: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               {{- end }}
         {{- end }}
         {{- if $persistence }}

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}
 {{- $waktusolat_registry := .Values.image.waktusolat.registry | default "ghcr.io" | toString }}
 {{- $waktusolat_repository := .Values.image.waktusolat.repository | default "irfanhakim-as/waktusolat" | toString }}
@@ -54,6 +55,14 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-mastodon-config
+              mountPath: /base/data/accounts.json
+              subPath: accounts.json
+              readOnly: true
             {{- if $celery }}
             - name: {{ .Release.Name }}-waktusolat-default-celery-config
               mountPath: /etc/default/celeryd
@@ -74,10 +83,12 @@ spec:
               mountPath: /base/base/__init__.py
               subPath: init.py
             {{- end }}
-            - name: {{ .Release.Name }}-waktusolat-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.waktusolat.mastodon }}
+            - name: {{ $release_name }}-waktusolat-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-waktusolat-logs
               mountPath: /var/log/apache2
@@ -98,6 +109,14 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-waktusolat-secret
           volumeMounts:
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-mastodon-config
+              mountPath: /base/data/accounts.json
+              subPath: accounts.json
+              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-apscheduler-config
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
@@ -107,10 +126,12 @@ spec:
             - name: {{ .Release.Name }}-waktusolat-scheduler-config
               mountPath: /base/base/tasks.py
               subPath: tasks.py
-            - name: {{ .Release.Name }}-waktusolat-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.waktusolat.mastodon }}
+            - name: {{ $release_name }}-waktusolat-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-waktusolat-logs
               mountPath: /var/log/apache2
@@ -130,6 +151,12 @@ spec:
         - name: {{ .Release.Name }}-waktusolat-site-config
           configMap:
             name: {{ .Release.Name }}-waktusolat-site-config
+        - name: {{ .Release.Name }}-waktusolat-feed-config
+          configMap:
+            name: {{ .Release.Name }}-waktusolat-feed-config
+        - name: {{ .Release.Name }}-waktusolat-mastodon-config
+          secret:
+            secretName: {{ .Release.Name }}-waktusolat-mastodon-config
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-waktusolat-apscheduler-config
           configMap:
@@ -174,9 +201,16 @@ spec:
               - key: tasks.py
                 path: tasks.py
         {{- end }}
+        {{- if .Values.waktusolat.mastodon }}
         - name: {{ .Release.Name }}-waktusolat-token-secret
           secret:
             secretName: {{ .Release.Name }}-waktusolat-token-secret
+            items:
+              {{- range .Values.waktusolat.mastodon }}
+              - key: {{ printf "%s.secret" .id | toString }}
+                path: {{ printf "%s.secret" .id | toString }}
+              {{- end }}
+        {{- end }}
         {{- if $persistence }}
         - name: {{ .Release.Name }}-waktusolat-logs
           persistentVolumeClaim:

--- a/mika/waktusolat/templates/feeds.json.tpl
+++ b/mika/waktusolat/templates/feeds.json.tpl
@@ -1,0 +1,17 @@
+{{/*
+Mastodon /base/lib/feeds.json template
+*/}}
+{{- define "waktusolat.feeds-json" -}}
+{
+    "feeds": [
+        {{- $feeds := .Values.waktusolat.feed }}
+        {{- range $index, $feed := $feeds }}
+        {
+            "uid": {{ $feed.id | toString | quote }},
+            "endpoint": {{ $feed.endpoint | toString | quote }},
+            "is_enabled": {{ $feed.enabled | default "true" | toString }},
+        }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/waktusolat/templates/secret.yaml
+++ b/mika/waktusolat/templates/secret.yaml
@@ -5,7 +5,6 @@
 {{- $db_password := .Values.db.password | toString | b64enc }}
 {{- $db_host := .Values.db.host | toString | b64enc }}
 {{- $db_port := .Values.db.port | default "5432" | toString | b64enc }}
-{{- $token := .Values.waktusolat.mastodon.token | toString | b64enc }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,10 +24,25 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ .Release.Name }}-waktusolat-mastodon-config
+  labels:
+    {{- include "waktusolat.labels" . | nindent 4 }}
+type: Opaque
+data:
+  accounts.json: |-
+    {{- include "waktusolat.accounts-json" . | toString | b64enc | nindent 4 }}
+{{- if .Values.waktusolat.mastodon }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ .Release.Name }}-waktusolat-token-secret
   labels:
     {{- include "waktusolat.labels" . | nindent 4 }}
 type: Opaque
 data:
-  mastodon.secret: |-
-    {{ $token | nindent 4 }}
+  {{- range .Values.waktusolat.mastodon }}
+  {{ printf "%s.secret" .id | toString }}: |-
+    {{ .token | toString | b64enc | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/mika/waktusolat/templates/secret.yaml
+++ b/mika/waktusolat/templates/secret.yaml
@@ -42,7 +42,8 @@ metadata:
 type: Opaque
 data:
   {{- range .Values.waktusolat.mastodon }}
-  {{ printf "%s.secret" .id | toString }}: |-
+  {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+  {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}: |-
     {{ .token | toString | b64enc | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -81,7 +81,7 @@ waktusolat:
   # mastodon:
   #   # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
   #   # Example:
-  #   # api: "https://botsin.space/"
+  #   # api: "https://botsin.space"
   #   - api: ""
   #   # The username or user account for the Mastodon instance of the WaktuSolat bot.
   #   # Example:

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -75,19 +75,62 @@ waktusolat:
   # location: "wlp-0"
   location: ""
   # WaktuSolat Mastodon configurations.
-  mastodon:
-    # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
-    # Example:
-    # api: "https://botsin.space/"
-    api: ""
-    # The username or user account for the Mastodon instance of the WaktuSolat bot.
-    # Example:
-    # bot: "waktusolat"
-    bot: ""
-    # A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API.
-    # Example:
-    # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
-    token: ""
+  # Example:
+  # mastodon:
+  #   # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
+  #   # Example:
+  #   # api: "https://botsin.space/"
+  #   - api: ""
+  #   # The username or user account for the Mastodon instance of the WaktuSolat bot.
+  #   # Example:
+  #   # id: "waktusolat"
+  #     id: ""
+  #   # A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API.
+  #   # Example:
+  #   # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
+  #     token: ""
+  #   # Specifies whether the WaktuSolat bot should be marked as a bot.
+  #   # Default: true
+  #   # Example:
+  #   # bot: false
+  #     bot: ""
+  #   # Specifies whether the WaktuSolat bot should appear in the user directory.
+  #   # Default: true
+  #   # Example:
+  #   # discoverable: false
+  #     discoverable: ""
+  #   # Specifies whether the WaktuSolat bot should be active.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
+  #   # The display name of the WaktuSolat bot.
+  #   # Default: null
+  #   # Example:
+  #   # display_name: "WaktuSolat"
+  #     display_name: ""
+  #   # A list of up to four name-value pairs information to be displayed on the WaktuSolat bot's profile.
+  #   # Default: []
+  #   # Example:
+  #   # fields:
+  #   #   - name: "Website 1"
+  #   #     value: "https://domain1.example.org"
+  #   #   - name: "Website 2"
+  #   #     value: "https://domain2.example.org"
+  #     fields:
+  #       - name: ""
+  #         value: ""
+  #   # Specifies whether the WaktuSolat bot needs to manually approve follow requests.
+  #   # Default: false
+  #   # Example:
+  #   # locked: true
+  #     locked: ""
+  #   # The bio of the WaktuSolat bot.
+  #   # Default: null
+  #   # Example:
+  #   # note: "This is the bio of the WaktuSolat bot."
+  #     note: ""
+  mastodon: []
   # WaktuSolat storage persistence configurations.
   persistence:
     # Specifies whether WaktuSolat should persist its storage.
@@ -106,6 +149,23 @@ waktusolat:
       # Example:
       # storage: "1Gi"
       storage: ""
+  # WaktuSolat feed configurations.
+  # Example:
+  # feed:
+  #   # The URL of the prayer time API feed to be used by WaktuSolat.
+  #   # Example:
+  #   # endpoint: "https://mpt.i906.my/api/prayer/%s"
+  #   - endpoint: ""
+  #   # The unique identifier of the API feed entry, must be an ISO 3166 Alpha-2 country code in uppercase.
+  #   # Example:
+  #   # id: "MY"
+  #     id: ""
+  #   # Specifies whether the API feed entry should be active to be used.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
+  feed: []
   # WaktuSolat scheduler configurations.
   scheduler:
     # Specifies whether APScheduler should be used by WaktuSolat as the task scheduler.

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -69,11 +69,13 @@ waktusolat:
   # Example:
   # visibility: "unlisted"
   visibility: ""
-  # The default location code used by WaktuSolat and its services.
+  # The code of locations WaktuSolat should fetch and update prayer times for.
   # Default: "wlp-0"
   # Example:
-  # location: "wlp-0"
-  location: ""
+  # location:
+  #   - "swk-33"
+  #   - "wlp-1"
+  location: []
   # WaktuSolat Mastodon configurations.
   # Example:
   # mastodon:

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -117,9 +117,7 @@ waktusolat:
   #   #     value: "https://domain1.example.org"
   #   #   - name: "Website 2"
   #   #     value: "https://domain2.example.org"
-  #     fields:
-  #       - name: ""
-  #         value: ""
+  #     fields: []
   #   # Specifies whether the WaktuSolat bot needs to manually approve follow requests.
   #   # Default: false
   #   # Example:


### PR DESCRIPTION
Based on Mango's new conventions in pre-release version, `0.1.0-multi-r1`+, and `0.1.0-update-r18`+.

## Changes

- Replaced old with new values/params structure for `.mastodon` and `.rss` (now replaced by `.feed`) configs in order to support multiple Mastodon accounts, and multiple data Feeds.
- Added JSON templates for the Mastodon and Feed configs.
- Added and mounted new configmap and secret for the Mastodon and Feed configs.
- Updated Mastodon token secret to support multiple secret files in order to support multiple accounts.
- WaktuSolat: Support multiple location codes for prayer time updates.
- WaktuSolat: #36.