### PR TITLE
Support multiple accounts and feeds for WaktuSolat

### DIFF
--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -117,9 +117,7 @@ rizz:
   #   #     value: "https://domain1.example.org"
   #   #   - name: "Website 2"
   #   #     value: "https://domain2.example.org"
-  #     fields:
-  #       - name: ""
-  #         value: ""
+  #     fields: []
   #   # Specifies whether the Rizz bot needs to manually approve follow requests.
   #   # Default: false
   #   # Example:

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-mango-r2"
+appVersion: "0.2.0-multi-r1"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times on Mastodon.
 type: application
 version: 0.3.0
-appVersion: "0.2.0-multi-r1"
+appVersion: "0.2.0-preview-r2"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -111,7 +111,7 @@ helm uninstall $release_name --namespace $namespace --wait
 | resources.waktusolat.requests.memory | string | `"60Mi"` | The minimum amount of memory required by WaktuSolat. |
 | waktusolat.debug | bool | `false` | Specifies whether WaktuSolat should run in debug mode. Default: `false`. |
 | waktusolat.domain | string | `""` | The domain name of the WaktuSolat service. Default: `"localhost"`. |
-| waktusolat.location | string | `""` | The default location code used by WaktuSolat and its services. Default: `"wlp-0"`. |
+| waktusolat.location | list | `[]` | The code of locations WaktuSolat should fetch and update prayer times for. Default: `"wlp-0"`. |
 | waktusolat.mastodon.api | string | `""` | API endpoint or URL for the Mastodon instance of the WaktuSolat bot. |
 | waktusolat.mastodon.bot | string | `""` | The username or user account for the Mastodon instance of the WaktuSolat bot. |
 | waktusolat.mastodon.token | string | `""` | A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API. |

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -111,10 +111,9 @@ helm uninstall $release_name --namespace $namespace --wait
 | resources.waktusolat.requests.memory | string | `"60Mi"` | The minimum amount of memory required by WaktuSolat. |
 | waktusolat.debug | bool | `false` | Specifies whether WaktuSolat should run in debug mode. Default: `false`. |
 | waktusolat.domain | string | `""` | The domain name of the WaktuSolat service. Default: `"localhost"`. |
+| waktusolat.feed | list | `[]` | WaktuSolat feed configurations. |
 | waktusolat.location | list | `[]` | The code of locations WaktuSolat should fetch and update prayer times for. Default: `"wlp-0"`. |
-| waktusolat.mastodon.api | string | `""` | API endpoint or URL for the Mastodon instance of the WaktuSolat bot. |
-| waktusolat.mastodon.bot | string | `""` | The username or user account for the Mastodon instance of the WaktuSolat bot. |
-| waktusolat.mastodon.token | string | `""` | A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API. |
+| waktusolat.mastodon | list | `[]` | WaktuSolat Mastodon configurations. |
 | waktusolat.persistence.enabled | bool | `false` | Specifies whether WaktuSolat should persist its storage. |
 | waktusolat.persistence.logs.storage | string | `""` | The amount of persistent storage allocated for WaktuSolat logs. Default: `"20Mi"`. |
 | waktusolat.persistence.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the WaktuSolat storage. Default: `"longhorn"`. |

--- a/mika/waktusolat/templates/accounts.json.tpl
+++ b/mika/waktusolat/templates/accounts.json.tpl
@@ -1,0 +1,40 @@
+{{/*
+Mastodon /base/lib/accounts.json template
+*/}}
+{{- define "waktusolat.accounts-json" -}}
+{
+    "accounts": [
+        {{- $accounts := .Values.waktusolat.mastodon }}
+        {{- range $index, $account := $accounts }}
+        {
+            "uid": {{ $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "api_base_url": {{ $account.api | toString | quote }},
+            "is_bot": {{ $account.bot | default "true" | toString }},
+            "is_discoverable": {{ $account.discoverable | default "true" | toString }},
+            "is_enabled": {{ $account.enabled | default "true" | toString }},
+            {{- if $account.display_name }}
+            "display_name": {{ $account.display_name | toString | quote }}
+            {{- else }}
+            "display_name": {{ $account.display_name | default "null" | toString }}
+            {{- end }},
+            "fields": [
+                {{- $fields := $account.fields }}
+                {{- range $i, $field := $fields }}
+                [
+                    {{ $field.name | toString | quote }},
+                    {{ $field.value | toString | quote }}
+                ]{{ if ne $i (sub (len $fields) 1) }},{{ end }}
+                {{- end }}
+            ],
+            "is_locked": {{ $account.locked | default "false" | toString }},
+            {{- if $account.note }}
+            "note": {{ $account.note | toString | quote }}
+            {{- else }}
+            "note": {{ $account.note | default "null" | toString }}
+            {{- end }}
+        }{{ if ne $index (sub (len $accounts) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/waktusolat/templates/accounts.json.tpl
+++ b/mika/waktusolat/templates/accounts.json.tpl
@@ -6,9 +6,10 @@ Mastodon /base/lib/accounts.json template
     "accounts": [
         {{- $accounts := .Values.waktusolat.mastodon }}
         {{- range $index, $account := $accounts }}
+        {{- $normalised_api := $account.api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
         {
             "uid": {{ $account.id | toString | quote }},
-            "access_token": {{ printf "/base/base/%s.secret" $account.id | toString | quote }},
+            "access_token": {{ printf "/base/base/%s-%s.secret" $account.id $normalised_api | toString | replace " " "" | quote }},
             "api_base_url": {{ $account.api | toString | quote }},
             "is_bot": {{ $account.bot | default "true" | toString }},
             "is_discoverable": {{ $account.discoverable | default "true" | toString }},

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -1,7 +1,5 @@
 {{- $debug := .Values.waktusolat.debug | default "false" | toString | quote }}
 {{- $location := .Values.waktusolat.location | default "wlp-0" | toString | quote }}
-{{- $api := .Values.waktusolat.mastodon.api | toString | quote }}
-{{- $bot := .Values.waktusolat.mastodon.bot | toString | quote }}
 {{- $visibility := .Values.waktusolat.visibility | default "public" | toString | quote }}
 {{- $post_limit := .Values.waktusolat.post_limit | default "0" | toString | quote }}
 {{- $scheduler_timezone := .Values.waktusolat.scheduler.timezone | default "Asia/Kuala_Lumpur" | toString | quote }}
@@ -22,8 +20,6 @@ metadata:
 data:
   DEBUG: {{ $debug }}
   LOCATION_CODE: {{ $location }}
-  API_BASE_URL: {{ $api }}
-  BOT_ID: {{ $bot }}
   DEFAULT_VISIBILITY: {{ $visibility }}
   POST_LIMIT: {{ $post_limit }}
   {{- if $celery }}
@@ -43,6 +39,16 @@ metadata:
 data:
   site-config.conf: |-
     {{- include "waktusolat.site-config-conf" . | replace "DOMAIN" $domain | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-waktusolat-feed-config
+  labels:
+    {{- include "waktusolat.labels" . | nindent 4 }}
+data:
+  feeds.json: |-
+    {{- include "waktusolat.feeds-json" . | toString | nindent 4 }}
 {{- if $apscheduler }}
 ---
 apiVersion: v1

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -39,6 +39,7 @@ metadata:
 data:
   site-config.conf: |-
     {{- include "waktusolat.site-config-conf" . | replace "DOMAIN" $domain | nindent 4 }}
+{{- if .Values.waktusolat.feed }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -49,6 +50,7 @@ metadata:
 data:
   feeds.json: |-
     {{- include "waktusolat.feeds-json" . | toString | nindent 4 }}
+{{- end }}
 {{- if $apscheduler }}
 ---
 apiVersion: v1

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $debug := .Values.waktusolat.debug | default "false" | toString | quote }}
-{{- $location := .Values.waktusolat.location | default "wlp-0" | toString | quote }}
+{{- $location := .Values.waktusolat.location | default "wlp-0" | join "," | toString | quote }}
 {{- $visibility := .Values.waktusolat.visibility | default "public" | toString | quote }}
 {{- $post_limit := .Values.waktusolat.post_limit | default "0" | toString | quote }}
 {{- $scheduler_timezone := .Values.waktusolat.scheduler.timezone | default "Asia/Kuala_Lumpur" | toString | quote }}

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "waktusolat.labels" . | nindent 4 }}
 data:
   DEBUG: {{ $debug }}
-  LOCATION_CODE: {{ $location }}
+  LOCATION_CODES: {{ $location }}
   DEFAULT_VISIBILITY: {{ $visibility }}
   POST_LIMIT: {{ $post_limit }}
   {{- if $celery }}

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -55,14 +55,16 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
-            - name: {{ .Release.Name }}-waktusolat-feed-config
-              mountPath: /base/data/feeds.json
-              subPath: feeds.json
-              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-mastodon-config
               mountPath: /base/data/accounts.json
               subPath: accounts.json
               readOnly: true
+            {{- if .Values.waktusolat.feed }}
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            {{- end }}
             {{- if $celery }}
             - name: {{ .Release.Name }}-waktusolat-default-celery-config
               mountPath: /etc/default/celeryd
@@ -109,10 +111,6 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-waktusolat-secret
           volumeMounts:
-            - name: {{ .Release.Name }}-waktusolat-feed-config
-              mountPath: /base/data/feeds.json
-              subPath: feeds.json
-              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-mastodon-config
               mountPath: /base/data/accounts.json
               subPath: accounts.json
@@ -130,6 +128,12 @@ spec:
             - name: {{ $release_name }}-waktusolat-token-secret
               mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
               subPath: {{ printf "%s.secret" .id | toString }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.waktusolat.feed }}
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -151,12 +155,14 @@ spec:
         - name: {{ .Release.Name }}-waktusolat-site-config
           configMap:
             name: {{ .Release.Name }}-waktusolat-site-config
-        - name: {{ .Release.Name }}-waktusolat-feed-config
-          configMap:
-            name: {{ .Release.Name }}-waktusolat-feed-config
         - name: {{ .Release.Name }}-waktusolat-mastodon-config
           secret:
             secretName: {{ .Release.Name }}-waktusolat-mastodon-config
+        {{- if .Values.waktusolat.feed }}
+        - name: {{ .Release.Name }}-waktusolat-feed-config
+          configMap:
+            name: {{ .Release.Name }}-waktusolat-feed-config
+        {{- end }}
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-waktusolat-apscheduler-config
           configMap:

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -86,9 +86,10 @@ spec:
               subPath: init.py
             {{- end }}
             {{- range .Values.waktusolat.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-waktusolat-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if $persistence }}
@@ -125,9 +126,10 @@ spec:
               mountPath: /base/base/tasks.py
               subPath: tasks.py
             {{- range .Values.waktusolat.mastodon }}
+            {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
             - name: {{ $release_name }}-waktusolat-token-secret
-              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
-              subPath: {{ printf "%s.secret" .id | toString }}
+              mountPath: {{ printf "/base/base/%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+              subPath: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               readOnly: true
             {{- end }}
             {{- if .Values.waktusolat.feed }}
@@ -213,8 +215,9 @@ spec:
             secretName: {{ .Release.Name }}-waktusolat-token-secret
             items:
               {{- range .Values.waktusolat.mastodon }}
-              - key: {{ printf "%s.secret" .id | toString }}
-                path: {{ printf "%s.secret" .id | toString }}
+              {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+              - key: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
+                path: {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}
               {{- end }}
         {{- end }}
         {{- if $persistence }}

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}
 {{- $waktusolat_registry := .Values.image.waktusolat.registry | default "ghcr.io" | toString }}
 {{- $waktusolat_repository := .Values.image.waktusolat.repository | default "irfanhakim-as/waktusolat" | toString }}
@@ -54,6 +55,14 @@ spec:
               mountPath: /etc/apache2/sites-available/000-default.conf
               subPath: site-config.conf
               readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-mastodon-config
+              mountPath: /base/data/accounts.json
+              subPath: accounts.json
+              readOnly: true
             {{- if $celery }}
             - name: {{ .Release.Name }}-waktusolat-default-celery-config
               mountPath: /etc/default/celeryd
@@ -74,10 +83,12 @@ spec:
               mountPath: /base/base/__init__.py
               subPath: init.py
             {{- end }}
-            - name: {{ .Release.Name }}-waktusolat-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.waktusolat.mastodon }}
+            - name: {{ $release_name }}-waktusolat-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-waktusolat-logs
               mountPath: /var/log/apache2
@@ -98,6 +109,14 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-waktusolat-secret
           volumeMounts:
+            - name: {{ .Release.Name }}-waktusolat-feed-config
+              mountPath: /base/data/feeds.json
+              subPath: feeds.json
+              readOnly: true
+            - name: {{ .Release.Name }}-waktusolat-mastodon-config
+              mountPath: /base/data/accounts.json
+              subPath: accounts.json
+              readOnly: true
             - name: {{ .Release.Name }}-waktusolat-apscheduler-config
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
@@ -107,10 +126,12 @@ spec:
             - name: {{ .Release.Name }}-waktusolat-scheduler-config
               mountPath: /base/base/tasks.py
               subPath: tasks.py
-            - name: {{ .Release.Name }}-waktusolat-token-secret
-              mountPath: /base/base/mastodon.secret
-              subPath: mastodon.secret
+            {{- range .Values.waktusolat.mastodon }}
+            - name: {{ $release_name }}-waktusolat-token-secret
+              mountPath: {{ printf "/base/base/%s.secret" .id | toString }}
+              subPath: {{ printf "%s.secret" .id | toString }}
               readOnly: true
+            {{- end }}
             {{- if $persistence }}
             - name: {{ .Release.Name }}-waktusolat-logs
               mountPath: /var/log/apache2
@@ -130,6 +151,12 @@ spec:
         - name: {{ .Release.Name }}-waktusolat-site-config
           configMap:
             name: {{ .Release.Name }}-waktusolat-site-config
+        - name: {{ .Release.Name }}-waktusolat-feed-config
+          configMap:
+            name: {{ .Release.Name }}-waktusolat-feed-config
+        - name: {{ .Release.Name }}-waktusolat-mastodon-config
+          secret:
+            secretName: {{ .Release.Name }}-waktusolat-mastodon-config
         {{- if $apscheduler }}
         - name: {{ .Release.Name }}-waktusolat-apscheduler-config
           configMap:
@@ -174,9 +201,16 @@ spec:
               - key: tasks.py
                 path: tasks.py
         {{- end }}
+        {{- if .Values.waktusolat.mastodon }}
         - name: {{ .Release.Name }}-waktusolat-token-secret
           secret:
             secretName: {{ .Release.Name }}-waktusolat-token-secret
+            items:
+              {{- range .Values.waktusolat.mastodon }}
+              - key: {{ printf "%s.secret" .id | toString }}
+                path: {{ printf "%s.secret" .id | toString }}
+              {{- end }}
+        {{- end }}
         {{- if $persistence }}
         - name: {{ .Release.Name }}-waktusolat-logs
           persistentVolumeClaim:

--- a/mika/waktusolat/templates/feeds.json.tpl
+++ b/mika/waktusolat/templates/feeds.json.tpl
@@ -1,0 +1,17 @@
+{{/*
+Mastodon /base/lib/feeds.json template
+*/}}
+{{- define "waktusolat.feeds-json" -}}
+{
+    "feeds": [
+        {{- $feeds := .Values.waktusolat.feed }}
+        {{- range $index, $feed := $feeds }}
+        {
+            "uid": {{ $feed.id | toString | quote }},
+            "endpoint": {{ $feed.endpoint | toString | quote }},
+            "is_enabled": {{ $feed.enabled | default "true" | toString }},
+        }{{ if ne $index (sub (len $feeds) 1) }},{{ end }}
+        {{- end }}
+    ]
+}
+{{- end }}

--- a/mika/waktusolat/templates/secret.yaml
+++ b/mika/waktusolat/templates/secret.yaml
@@ -5,7 +5,6 @@
 {{- $db_password := .Values.db.password | toString | b64enc }}
 {{- $db_host := .Values.db.host | toString | b64enc }}
 {{- $db_port := .Values.db.port | default "5432" | toString | b64enc }}
-{{- $token := .Values.waktusolat.mastodon.token | toString | b64enc }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,10 +24,25 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ .Release.Name }}-waktusolat-mastodon-config
+  labels:
+    {{- include "waktusolat.labels" . | nindent 4 }}
+type: Opaque
+data:
+  accounts.json: |-
+    {{- include "waktusolat.accounts-json" . | toString | b64enc | nindent 4 }}
+{{- if .Values.waktusolat.mastodon }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ .Release.Name }}-waktusolat-token-secret
   labels:
     {{- include "waktusolat.labels" . | nindent 4 }}
 type: Opaque
 data:
-  mastodon.secret: |-
-    {{ $token | nindent 4 }}
+  {{- range .Values.waktusolat.mastodon }}
+  {{ printf "%s.secret" .id | toString }}: |-
+    {{ .token | toString | b64enc | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/mika/waktusolat/templates/secret.yaml
+++ b/mika/waktusolat/templates/secret.yaml
@@ -42,7 +42,8 @@ metadata:
 type: Opaque
 data:
   {{- range .Values.waktusolat.mastodon }}
-  {{ printf "%s.secret" .id | toString }}: |-
+  {{- $normalised_api := .api | toString | replace "https" "" | replace ":" "" | replace "/" "" }}
+  {{ printf "%s-%s.secret" .id $normalised_api | toString | replace " " "" }}: |-
     {{ .token | toString | b64enc | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -81,7 +81,7 @@ waktusolat:
   # mastodon:
   #   # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
   #   # Example:
-  #   # api: "https://botsin.space/"
+  #   # api: "https://botsin.space"
   #   - api: ""
   #   # The username or user account for the Mastodon instance of the WaktuSolat bot.
   #   # Example:

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -75,19 +75,62 @@ waktusolat:
   # location: "wlp-0"
   location: ""
   # WaktuSolat Mastodon configurations.
-  mastodon:
-    # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
-    # Example:
-    # api: "https://botsin.space/"
-    api: ""
-    # The username or user account for the Mastodon instance of the WaktuSolat bot.
-    # Example:
-    # bot: "waktusolat"
-    bot: ""
-    # A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API.
-    # Example:
-    # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
-    token: ""
+  # Example:
+  # mastodon:
+  #   # API endpoint or URL for the Mastodon instance of the WaktuSolat bot.
+  #   # Example:
+  #   # api: "https://botsin.space/"
+  #   - api: ""
+  #   # The username or user account for the Mastodon instance of the WaktuSolat bot.
+  #   # Example:
+  #   # id: "waktusolat"
+  #     id: ""
+  #   # A secure token required to authenticate the WaktuSolat service with the Mastodon instance's API.
+  #   # Example:
+  #   # token: "6&p4%t)-$8a14fmfh92py8j55+us51r6%e52dzy&=a3-6yd4#e"
+  #     token: ""
+  #   # Specifies whether the WaktuSolat bot should be marked as a bot.
+  #   # Default: true
+  #   # Example:
+  #   # bot: false
+  #     bot: ""
+  #   # Specifies whether the WaktuSolat bot should appear in the user directory.
+  #   # Default: true
+  #   # Example:
+  #   # discoverable: false
+  #     discoverable: ""
+  #   # Specifies whether the WaktuSolat bot should be active.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
+  #   # The display name of the WaktuSolat bot.
+  #   # Default: null
+  #   # Example:
+  #   # display_name: "WaktuSolat"
+  #     display_name: ""
+  #   # A list of up to four name-value pairs information to be displayed on the WaktuSolat bot's profile.
+  #   # Default: []
+  #   # Example:
+  #   # fields:
+  #   #   - name: "Website 1"
+  #   #     value: "https://domain1.example.org"
+  #   #   - name: "Website 2"
+  #   #     value: "https://domain2.example.org"
+  #     fields:
+  #       - name: ""
+  #         value: ""
+  #   # Specifies whether the WaktuSolat bot needs to manually approve follow requests.
+  #   # Default: false
+  #   # Example:
+  #   # locked: true
+  #     locked: ""
+  #   # The bio of the WaktuSolat bot.
+  #   # Default: null
+  #   # Example:
+  #   # note: "This is the bio of the WaktuSolat bot."
+  #     note: ""
+  mastodon: []
   # WaktuSolat storage persistence configurations.
   persistence:
     # Specifies whether WaktuSolat should persist its storage.
@@ -106,6 +149,23 @@ waktusolat:
       # Example:
       # storage: "1Gi"
       storage: ""
+  # WaktuSolat feed configurations.
+  # Example:
+  # feed:
+  #   # The URL of the prayer time API feed to be used by WaktuSolat.
+  #   # Example:
+  #   # endpoint: "https://mpt.i906.my/api/prayer/%s"
+  #   - endpoint: ""
+  #   # The unique identifier of the API feed entry, must be an ISO 3166 Alpha-2 country code in uppercase.
+  #   # Example:
+  #   # id: "MY"
+  #     id: ""
+  #   # Specifies whether the API feed entry should be active to be used.
+  #   # Default: true
+  #   # Example:
+  #   # enabled: false
+  #     enabled: ""
+  feed: []
   # WaktuSolat scheduler configurations.
   scheduler:
     # Specifies whether APScheduler should be used by WaktuSolat as the task scheduler.

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -69,11 +69,13 @@ waktusolat:
   # Example:
   # visibility: "unlisted"
   visibility: ""
-  # The default location code used by WaktuSolat and its services.
+  # The code of locations WaktuSolat should fetch and update prayer times for.
   # Default: "wlp-0"
   # Example:
-  # location: "wlp-0"
-  location: ""
+  # location:
+  #   - "swk-33"
+  #   - "wlp-1"
+  location: []
   # WaktuSolat Mastodon configurations.
   # Example:
   # mastodon:

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -117,9 +117,7 @@ waktusolat:
   #   #     value: "https://domain1.example.org"
   #   #   - name: "Website 2"
   #   #     value: "https://domain2.example.org"
-  #     fields:
-  #       - name: ""
-  #         value: ""
+  #     fields: []
   #   # Specifies whether the WaktuSolat bot needs to manually approve follow requests.
   #   # Default: false
   #   # Example:


### PR DESCRIPTION
## Changes

- Support multiple accounts and feeds for the WaktuSolat chart #35.
- Support adding multiple locations for prayer time updates.
- Feed config is optional for WaktuSolat as the image already comes with a usable default.
- Make token secret file name unique by adding a normalised `api_base_url` value to the file name in addition to `id`.