### PR TITLE
Flex: Allow configuring data storage allocation for each supporting container

### DIFF
--- a/mika/flex/Chart.yaml
+++ b/mika/flex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flex
 description: Flex is a collection of curated services that aims to provide a complete home media server solution.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.32.8.7639-fb6452ebf"
 keywords:
   - "flex"

--- a/mika/flex/README.md
+++ b/mika/flex/README.md
@@ -651,7 +651,7 @@ Flex is a collection of curated services that aims to provide a complete home me
 | sonarr.ingress | bool | `false` | Specifies whether Sonarr should be hosted using an Ingress. |
 | storage.data.enabled | bool | `true` | Specifies whether persistent storage should be provisioned for data storage. |
 | storage.data.mountPath | string | `""` | The path where the data storage should be mounted on the container. Default: `"/config"`. |
-| storage.data.storage | string | `""` | The amount of persistent storage allocated for each data storage. Default: `"1Gi"`. |
+| storage.data.storage | string | `""` | The default amount of persistent storage allocated for each data storage. Default: `"1Gi"`. |
 | storage.data.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the data storage. Default: `"longhorn"`. |
 | storage.data.subPath | string | `""` | The subpath within the data storage to mount to the container. Leave empty if not required. |
 | storage.downloads.enabled | bool | `false` | Specifies whether persistent storage should be provisioned for downloads storage. |

--- a/mika/flex/README.md
+++ b/mika/flex/README.md
@@ -613,20 +613,25 @@ Flex is a collection of curated services that aims to provide a complete home me
 | ingress.enabled | bool | `false` | Specifies whether Ingress should be enabled for hosting Flex services. |
 | jackett.autoUpdate | bool | `true` | Specifies whether to allow Jackett to automatically update itself inside the container. |
 | jackett.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the Jackett container. |
+| jackett.dataStorage | string | `""` | The amount of persistent storage allocated for the Jackett data storage. |
 | jackett.domain | string | `""` | The ingress domain name that hosts the Jackett server. |
 | jackett.ingress | bool | `false` | Specifies whether Jackett should be hosted using an Ingress. |
 | overseerr.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the Overseerr container. |
+| overseerr.dataStorage | string | `""` | The amount of persistent storage allocated for the Overseerr data storage. |
 | overseerr.domain | string | `""` | The ingress domain name that hosts the Overseerr server. |
 | overseerr.ingress | bool | `false` | Specifies whether Overseerr should be hosted using an Ingress. |
 | plex.claim | string | `""` | The secret claim token used to claim ownership of the Plex server. Get it from https://www.plex.tv/claim. |
 | plex.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the Plex container. |
+| plex.dataStorage | string | `""` | The amount of persistent storage allocated for the Plex data storage. |
 | plex.domain | string | `""` | The ingress domain name that hosts the Plex server. |
 | plex.ingress | bool | `false` | Specifies whether Plex should be hosted using an Ingress. |
 | qbt.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the qBittorrent container. |
+| qbt.dataStorage | string | `""` | The amount of persistent storage allocated for the qBittorrent data storage. |
 | qbt.domain | string | `""` | The ingress domain name that hosts the qBittorrent server. |
 | qbt.enabled | bool | `true` | Specifies whether qBittorrent should be deployed or excluded in case an external qBittorrent server is used. |
 | qbt.ingress | bool | `false` | Specifies whether qBittorrent should be hosted using an Ingress. |
 | radarr.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the Radarr container. |
+| radarr.dataStorage | string | `""` | The amount of persistent storage allocated for the Radarr data storage. |
 | radarr.domain | string | `""` | The ingress domain name that hosts the Radarr server. |
 | radarr.ingress | bool | `false` | Specifies whether Radarr should be hosted using an Ingress. |
 | replicaCount | string | `""` | The desired number of running replicas for Flex. Default: `"1"`. |
@@ -647,6 +652,7 @@ Flex is a collection of curated services that aims to provide a complete home me
 | smb.share | string | `""` | The SMB share address and name to mount as a persistent volume. |
 | smb.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the SMB share storage. Default: `"smb"`. |
 | sonarr.customConfigs | list | `[]` | Optional custom configurations to be mounted as a file inside the Sonarr container. |
+| sonarr.dataStorage | string | `""` | The amount of persistent storage allocated for the Sonarr data storage. |
 | sonarr.domain | string | `""` | The ingress domain name that hosts the Sonarr server. |
 | sonarr.ingress | bool | `false` | Specifies whether Sonarr should be hosted using an Ingress. |
 | storage.data.enabled | bool | `true` | Specifies whether persistent storage should be provisioned for data storage. |

--- a/mika/flex/templates/pvc.yaml
+++ b/mika/flex/templates/pvc.yaml
@@ -7,7 +7,7 @@
 {{- $downloadsSmb := .Values.storage.downloads.smb }}
 {{- $globalSmb := .Values.storage.global.smb }}
 {{- $mediaSmb := .Values.storage.media.smb }}
-{{- $dataStorage := .Values.storage.data.storage | default "1Gi" | toString | quote }}
+{{- $dataStorage := .Values.storage.data.storage | default "1Gi" | toString }}
 {{- $dataStorageClassName := .Values.storage.data.storageClassName | default "longhorn" | toString | quote }}
 {{- $downloadsStorage := .Values.storage.downloads.storage | default "1Gi" | toString | quote }}
 {{- $downloadsStorageClassName := .Values.storage.downloads.storageClassName | default "longhorn" | toString | quote }}
@@ -17,6 +17,12 @@
 {{- $mediaStorageClassName := .Values.storage.media.storageClassName | default "longhorn" | toString | quote }}
 {{- $smbStorage := .Values.smb.pvcStorage | default "1Gi" | toString | quote }}
 {{- $smbStorageClassName := .Values.smb.storageClassName | default "smb" | toString | quote }}
+{{- $jackettDataStorage := .Values.jackett.dataStorage | default $dataStorage | toString | quote }}
+{{- $overseerrDataStorage := .Values.overseerr.dataStorage | default $dataStorage | toString | quote }}
+{{- $plexDataStorage := .Values.plex.dataStorage | default $dataStorage | toString | quote }}
+{{- $qbtDataStorage := .Values.qbt.dataStorage | default $dataStorage | toString | quote }}
+{{- $radarrDataStorage := .Values.radarr.dataStorage | default $dataStorage | toString | quote }}
+{{- $sonarrDataStorage := .Values.sonarr.dataStorage | default $dataStorage | toString | quote }}
 {{- if $persistent_data }}
 ---
 apiVersion: v1
@@ -30,7 +36,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $jackettDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 ---
 apiVersion: v1
@@ -44,7 +50,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $overseerrDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 ---
 apiVersion: v1
@@ -58,7 +64,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $plexDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 {{- if $qbt }}
 ---
@@ -73,7 +79,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $qbtDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 {{- end }}
 ---
@@ -88,7 +94,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $radarrDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 ---
 apiVersion: v1
@@ -102,7 +108,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $dataStorage }}
+      storage: {{ $sonarrDataStorage }}
   storageClassName: {{ $dataStorageClassName }}
 {{- end }}
 {{- if and $persistent_downloads (not (and $downloadsSmb $smb)) (not $persistent_global) }}

--- a/mika/flex/values.yaml
+++ b/mika/flex/values.yaml
@@ -186,6 +186,10 @@ jackett:
   # Example:
   # autoUpdate: false
   autoUpdate: true
+  # The amount of persistent storage allocated for the Jackett data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the Jackett server.
   # Example:
   # domain: "jackett.example.com"
@@ -209,6 +213,10 @@ jackett:
 
 # Overseerr configurations.
 overseerr:
+  # The amount of persistent storage allocated for the Overseerr data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the Overseerr server.
   # Example:
   # domain: "overseerr.example.com"
@@ -236,6 +244,10 @@ plex:
   # Example:
   # claim: "claim-bW419gvogwjNfYCowOGa"
   claim: ""
+  # The amount of persistent storage allocated for the Plex data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the Plex server.
   # Example:
   # domain: "plex.example.com"
@@ -259,6 +271,10 @@ plex:
 
 # qBittorrent configurations.
 qbt:
+  # The amount of persistent storage allocated for the qBittorrent data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the qBittorrent server.
   # Example:
   # domain: "qbt.example.com"
@@ -286,6 +302,10 @@ qbt:
 
 # Radarr configurations.
 radarr:
+  # The amount of persistent storage allocated for the Radarr data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the Radarr server.
   # Example:
   # domain: "radarr.example.com"
@@ -309,6 +329,10 @@ radarr:
 
 # Sonarr configurations.
 sonarr:
+  # The amount of persistent storage allocated for the Sonarr data storage.
+  # Example:
+  # dataStorage: "10Gi"
+  dataStorage: ""
   # The ingress domain name that hosts the Sonarr server.
   # Example:
   # domain: "sonarr.example.com"

--- a/mika/flex/values.yaml
+++ b/mika/flex/values.yaml
@@ -365,7 +365,7 @@ storage:
     # Example:
     # subPath: "Config"
     subPath: ""
-    # The amount of persistent storage allocated for each data storage.
+    # The default amount of persistent storage allocated for each data storage.
     # Default: "1Gi"
     # Example:
     # storage: "1Gi"


### PR DESCRIPTION
# Changes

- Allow configuring data storage per (supporting) container. This allows containers such as Plex that may require a lot more storage for their data volume for things such as media metadata and thumbnails.
- `storage.data.storage` can still be used to set the default size allocation for each container's data storage.