### PR TITLE
mariadb-agent: Support MySQL 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Applications, developed or curated by [mika](https://github.com/irfanhakim-as), 
 | [kutt](mika/kutt) | Kutt is a modern URL shortener with support for custom domains. Shorten URLs, manage your links and view the click rate statistics. | ✅ | ✅ |
 | [linkstack](mika/linkstack) | LinkStack is a highly customizable link sharing platform with an intuitive, easy to use user interface. | ✅ | ✅ |
 | [littlelink](mika/littlelink) | The DIY self-hosted LinkTree alternative. | ✅ | ✅ |
-| [mariadb-agent](mika/mariadb-agent) | Easily create or delete multiple pairs of databases and users in a remote MariaDB instance. | ✅ | ✅ |
+| [mariadb-agent](mika/mariadb-agent) | Easily create or delete multiple pairs of databases and users in a remote MariaDB or MySQL instance. | ✅ | ✅ |
 | [postgres](mika/postgres) | Easy tool to deploy a PostgreSQL instance on Kubernetes. | ✅ | ✅ |
 | [postgres-agent](mika/postgres-agent) | Easily create or delete a database and user pair in a remote PostgreSQL instance. | ✅ | ✅ |
 | [rizz](mika/rizz) | Rizz is a simple web application that tracks and posts content from RSS Feeds to Mastodon. | ✅ | 🔒 |

--- a/mika/mariadb-agent/Chart.yaml
+++ b/mika/mariadb-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb-agent
 description: Easily create or delete multiple pairs of databases and users in a remote MariaDB or MySQL instance.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "11.1.3-debian-11-r0"
 keywords:
   - "mariadb"

--- a/mika/mariadb-agent/Chart.yaml
+++ b/mika/mariadb-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mariadb-agent
-description: Easily create or delete multiple pairs of databases and users in a remote MariaDB instance.
+description: Easily create or delete multiple pairs of databases and users in a remote MariaDB or MySQL instance.
 type: application
 version: 0.1.2
 appVersion: "11.1.3-debian-11-r0"

--- a/mika/mariadb-agent/README.md
+++ b/mika/mariadb-agent/README.md
@@ -1,6 +1,6 @@
 # [MariaDB-Agent](https://github.com/MariaDB/server)
 
-Easily create or delete multiple pairs of databases and users in a remote MariaDB instance.
+Easily create or delete multiple pairs of databases and users in a remote MariaDB or MySQL instance.
 
 ## Prerequisites
 

--- a/mika/mariadb-agent/README.md
+++ b/mika/mariadb-agent/README.md
@@ -132,6 +132,7 @@ Easily create or delete multiple pairs of databases and users in a remote MariaD
 | image.mariadb.repository | string | `""` | The name of the repository that contains the MariaDB container image used. Default: `"bitnami/mariadb"`. |
 | image.mariadb.tag | string | `""` | The tag that specifies the version of the MariaDB container image used. Default: `Chart appVersion`. |
 | imagePullSecrets | list | `[]` | Credentials used to securely authenticate and authorise the pulling of container images from private registries. |
+| mariadb.client | string | `""` | The command-line client tool to connect to the database server. Default: `"mariadb"`. |
 | mariadb.databases | list | `[]` | Database configurations array. Items: `.name`, `.user`, `.password`, `.create`, `.drop`, `.custom`, `.custom_command`. |
 | mariadb.host | string | `""` | The hostname or IP address of the MariaDB database server. |
 | mariadb.port | string | `""` | The port number the MariaDB database server is listening for connections. Default: `"3306"`. |

--- a/mika/mariadb-agent/templates/job.yaml
+++ b/mika/mariadb-agent/templates/job.yaml
@@ -1,8 +1,9 @@
+{{- $databases := .Values.mariadb.databases }}
 {{- $mariadb_registry := .Values.image.mariadb.registry | default "docker.io" | toString }}
 {{- $mariadb_repository := .Values.image.mariadb.repository | default "bitnami/mariadb" | toString }}
 {{- $mariadb_tag := .Values.image.mariadb.tag | default .Chart.AppVersion | toString }}
 {{- $mariadb_pullPolicy := .Values.image.mariadb.pullPolicy | default "IfNotPresent" | toString | quote }}
-{{- $databases := .Values.mariadb.databases }}
+{{- $client := .Values.mariadb.client | default "mariadb" | toString }}
 {{- $mariadbHost := .Values.mariadb.host | default "mariadb" | toString }}
 ---
 apiVersion: batch/v1
@@ -37,7 +38,7 @@ spec:
           args:
             - -c
             - >-
-              mariadb -h $(DB_HOST) -P $(DB_PORT) -u $(ROOT_USER) -e '
+              {{ $client }} -h $(DB_HOST) -P $(DB_PORT) -u $(ROOT_USER) -e '
             {{- range $databases }}
               {{- $create := .create }}
               {{- $drop := .drop }}

--- a/mika/mariadb-agent/templates/job.yaml
+++ b/mika/mariadb-agent/templates/job.yaml
@@ -52,7 +52,7 @@ spec:
               {{- end }}
               {{- if $create }}
                 CREATE USER IF NOT EXISTS {{ $user | quote }}@"%";
-                SET PASSWORD FOR {{ $user | quote }}@"%" = PASSWORD({{ $password | quote }});
+                ALTER USER {{ $user | quote }}@"%" IDENTIFIED BY {{ $password | quote }};
                 CREATE DATABASE IF NOT EXISTS {{ $db }};
                 GRANT ALL PRIVILEGES ON {{ $db }}.* TO {{ $user | quote }}@"%";
               {{- end }}

--- a/mika/mariadb-agent/values.yaml
+++ b/mika/mariadb-agent/values.yaml
@@ -28,6 +28,11 @@ imagePullSecrets: []
 
 # MariaDB-Agent configurations.
 mariadb:
+  # The command-line client tool to connect to the database server.
+  # Default: "mariadb"
+  # Example:
+  # client: "mysql"
+  client: ""
   # The hostname or IP address of the MariaDB database server.
   # Example:
   # host: "mariadb.default.svc.cluster.local"


### PR DESCRIPTION
# Changes

- Added new `mariadb.client` value to specify client tool to use to connect to DB server
- Updated password update command to support MySQL 8 (in addition to MariaDB 11)