### PR TITLE
snipe-it: Fix wrong env var

### DIFF
--- a/mika/snipe-it/Chart.yaml
+++ b/mika/snipe-it/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snipe-it
 description: Snipe-IT was made for IT asset management, to enable IT departments to track who has which laptop, when it was purchased, which software licenses and accessories are available, and so on.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v8.1.15-alpine"
 keywords:
   - "snipe-it"

--- a/mika/snipe-it/templates/configmap.yaml
+++ b/mika/snipe-it/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
   LOG: {{ $logMode }}
   APP_LOG_MAX_FILES: {{ $logMaxFiles }}
   LOG_LEVEL: {{ $logLevel }}
+  IMAGE_LIB: "gd"
   PRIVATE_FILESYSTEM_DISK: "local"
   PUBLIC_FILESYSTEM_DISK: "local_public"
   MAIL_MAILER: "smtp"

--- a/mika/snipe-it/templates/configmap.yaml
+++ b/mika/snipe-it/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
   APP_FORCE_TLS: {{ $secure }}
   APP_ALLOW_INSECURE_HOSTS: {{ $allowInsecureHosts }}
   MAX_RESULTS: {{ $maxResults }}
-  LOG: {{ $logMode }}
+  LOG_CHANNEL: {{ $logMode }}
   APP_LOG_MAX_FILES: {{ $logMaxFiles }}
   LOG_LEVEL: {{ $logLevel }}
   IMAGE_LIB: "gd"

--- a/mika/snipe-it/templates/configmap.yaml
+++ b/mika/snipe-it/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
   APP_ALLOW_INSECURE_HOSTS: {{ $allowInsecureHosts }}
   MAX_RESULTS: {{ $maxResults }}
   LOG_CHANNEL: {{ $logMode }}
-  APP_LOG_MAX_FILES: {{ $logMaxFiles }}
+  LOG_MAX_DAYS: {{ $logMaxFiles }}
   LOG_LEVEL: {{ $logLevel }}
   IMAGE_LIB: "gd"
   PRIVATE_FILESYSTEM_DISK: "local"


### PR DESCRIPTION
# Changes

- Added missing `IMAGE_LIB` env variable - things seem to work fine without it, but added anyway due to it being required
- Renamed `LOG` env var to `LOG_CHANNEL` - wrongly documented in the Snipe-IT docs
- Renamed `APP_LOG_MAX_FILES` env var to `LOG_MAX_DAYS` - wrongly documented in the Snipe-IT docs
- Bumped chart version to `0.1.1`

# Notes

Pretty common to find inconsistencies across current Snipe-IT docs, there might be variables implemented in the chart today that either have been replaced or even removed entirely. Besides the earlier examples, `LOG_LEVEL` for instance is documented in their official [Configuration docs](https://snipe-it.readme.io/docs/configuration), but not included in the full `.env` file.

The chart will be updated accordingly upon any further discoveries on these discrepancies.