### PR TITLE
extsvc: Support service-specific custom annotations

### DIFF
--- a/mika/external-svc/Chart.yaml
+++ b/mika/external-svc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-svc
 description: Seamlessly connect external services to your Kubernetes environment.
 type: application
-version: 0.1.0
+version: 0.1.1
 keywords:
   - "external-svc"
   - "external"

--- a/mika/external-svc/README.md
+++ b/mika/external-svc/README.md
@@ -128,6 +128,6 @@ Seamlessly connect external services to your Kubernetes environment.
 |-----|------|---------|-------------|
 | ingress.clusterIssuer | string | `""` | The name of the cluster issuer for Ingress. Default: `"letsencrypt-dns-prod"`. |
 | ingress.customAnnotations | list | `[]` | Additional configuration annotations to be added to the Ingress resource of each external service. Items: `.prefix`, `.name`, `.value`. |
-| ingress.domains | list | `[]` | Domain configurations. Items: `.name`, `.port`, `.www`. |
+| ingress.domains | list | `[]` | Domain configurations. Items: `.name`, `.port`, `.www`, `.customAnnotations`. |
 | ingress.enabled | bool | `false` | Specifies whether Ingress should be enabled for hosting External Service services. |
 | services | list | `[]` | Service configurations. Items: `.host`, `.name`, `.nodePort`, `.port`, `.targetPort`, `.type`. |

--- a/mika/external-svc/README.md
+++ b/mika/external-svc/README.md
@@ -127,7 +127,7 @@ Seamlessly connect external services to your Kubernetes environment.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ingress.clusterIssuer | string | `""` | The name of the cluster issuer for Ingress. Default: `"letsencrypt-dns-prod"`. |
-| ingress.customAnnotations | list | `[]` | Additional configuration annotations to be added to the Ingress resource. Items: `.prefix`, `.name`, `.value`. |
+| ingress.customAnnotations | list | `[]` | Additional configuration annotations to be added to the Ingress resource of each external service. Items: `.prefix`, `.name`, `.value`. |
 | ingress.domains | list | `[]` | Domain configurations. Items: `.name`, `.port`, `.www`. |
 | ingress.enabled | bool | `false` | Specifies whether Ingress should be enabled for hosting External Service services. |
 | services | list | `[]` | Service configurations. Items: `.host`, `.name`, `.nodePort`, `.port`, `.targetPort`, `.type`. |

--- a/mika/external-svc/templates/NOTES.txt
+++ b/mika/external-svc/templates/NOTES.txt
@@ -38,8 +38,9 @@ The following are a list of domain(s) you have supplied for the external service
         {{- $www := $domain.www | toString }}
         {{- $name := $domain.name | toString }}
         {{- $port := $domain.port | toString }}
+        {{- $customAnnotations := ternary "true" "false" (not (empty $domain.customAnnotations)) | toString }}
 
-    {{ printf "%s. name=%s | domain=%s | www=%s" ($index | add1 | toString) $port $name $www }}
+    {{ printf "%s. name=%s | domain=%s | www=%s | custom_annotations=%s" ($index | add1 | toString) $port $name $www $customAnnotations }}
 
     {{- end }}
 

--- a/mika/external-svc/templates/NOTES.txt
+++ b/mika/external-svc/templates/NOTES.txt
@@ -35,11 +35,11 @@ The following are a list of domain(s) you have supplied for the external service
 {{- else }}
 
     {{- range $index, $domain := $domains }}
-        {{- $www := $domain.www }}
+        {{- $www := $domain.www | toString }}
         {{- $name := $domain.name | toString }}
         {{- $port := $domain.port | toString }}
 
-    {{ printf "%s. name=%s | domain=%s | www=%s" ($index | add1 | toString) $port $name ($www | toString) }}
+    {{ printf "%s. name=%s | domain=%s | www=%s" ($index | add1 | toString) $port $name $www }}
 
     {{- end }}
 

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $ingress := .Values.ingress.enabled }}
-{{- $customAnnotations := .Values.ingress.customAnnotations }}
+{{- $defaultCustomAnnotations := .Values.ingress.customAnnotations }}
 {{- $domains := .Values.ingress.domains }}
 {{- $services := .Values.services }}
 {{- $clusterIssuer := .Values.ingress.clusterIssuer | default "letsencrypt-dns-prod" | toString | quote }}
@@ -27,7 +27,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.org/client-max-body-size: "100m"
-    {{- range $customAnnotations }}
+    {{- range $defaultCustomAnnotations }}
     {{ printf "%s/%s" (.prefix | default "nginx.ingress.kubernetes.io") .name }}: {{ .value | quote }}
     {{- end }}
 spec:

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -6,6 +6,7 @@
 {{- $releaseName := .Release.Name | toString }}
 {{- if and $ingress $services $domains }}
 {{- range $domains }}
+{{- $customAnnotations := .customAnnotations }}
 {{- $www := .www }}
 {{- $name := .name | toString }}
 {{- $port := .port | toString }}
@@ -28,6 +29,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.org/client-max-body-size: "100m"
     {{- range $defaultCustomAnnotations }}
+    {{ printf "%s/%s" (.prefix | default "nginx.ingress.kubernetes.io") .name }}: {{ .value | quote }}
+    {{- end }}
+    {{- range $customAnnotations }}
     {{ printf "%s/%s" (.prefix | default "nginx.ingress.kubernetes.io") .name }}: {{ .value | quote }}
     {{- end }}
 spec:

--- a/mika/external-svc/values.yaml
+++ b/mika/external-svc/values.yaml
@@ -45,7 +45,7 @@ ingress:
   # Example:
   # clusterIssuer: "letsencrypt-http-prod"
   clusterIssuer: ""
-  # Additional configuration annotations to be added to the Ingress resource.
+  # Additional configuration annotations to be added to the Ingress resource of each external service.
   # Items: `.prefix`, `.name`, `.value`
   # Example:
   # customAnnotations:

--- a/mika/external-svc/values.yaml
+++ b/mika/external-svc/values.yaml
@@ -64,7 +64,7 @@ ingress:
   #     value: ""
   customAnnotations: []
   # Domain configurations.
-  # Items: `.name`, `.port`, `.www`
+  # Items: `.name`, `.port`, `.www`, `.customAnnotations`
   # Example:
   # domains:
   #   # The ingress domain name that hosts the external service.
@@ -79,4 +79,22 @@ ingress:
   #   # Example:
   #   # www: true
   #     www: false
+  #   # Additional configuration annotations to be added to the Ingress resource.
+  #   # Items: `.prefix`, `.name`, `.value`
+  #   # Example:
+  #   # customAnnotations:
+  #   #   # The prefix of the annotation.
+  #   #   # Default: "nginx.ingress.kubernetes.io"
+  #   #   # Example:
+  #   #   # prefix: "nginx.org"
+  #   #   - prefix: ""
+  #   #   # The name of the annotation.
+  #   #   # Example:
+  #   #   # name: "proxy-connect-timeout"
+  #   #     name: ""
+  #   #   # The value of the annotation.
+  #   #   # Example:
+  #   #   # value: "120"
+  #   #     value: ""
+  #     customAnnotations: []
   domains: []


### PR DESCRIPTION
# Changes

- Added new supported option for `ingress.domains`: `customAnnotations` - which allows adding custom annotations to specific services in addition to the global custom annotations
- Minor changes to the chart notes and template
- Bumped chart version to `0.1.1`