### PR TITLE
CloudflareDDNS: Replace upstream cloudflareddns image

### DIFF
--- a/mika/cloudflareddns/Chart.yaml
+++ b/mika/cloudflareddns/Chart.yaml
@@ -3,7 +3,7 @@ name: cloudflareddns
 description: Access your home network remotely via a custom domain name without a static IP!
 type: application
 version: 0.1.1
-appVersion: "latest"
+appVersion: "1.0.2-fix-wrong-ip-r3"
 keywords:
   - "cloudflareddns"
   - "cloudflare"

--- a/mika/cloudflareddns/Chart.yaml
+++ b/mika/cloudflareddns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudflareddns
 description: Access your home network remotely via a custom domain name without a static IP!
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0.2-fix-wrong-ip-r3"
 keywords:
   - "cloudflareddns"

--- a/mika/cloudflareddns/README.md
+++ b/mika/cloudflareddns/README.md
@@ -135,8 +135,8 @@ Access your home network remotely via a custom domain name without a static IP!
 | cloudflareddns.ttl | string | `""` | The Time-To-Live (TTL) duration defining how long DNS records are cached in seconds. Default: `"300"`. |
 | cloudflareddns.zoneID | string | `""` | The ID of the zone that will get the records. |
 | image.cloudflareddns.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Cloudflare DDNS container image. Default: `"IfNotPresent"`. |
-| image.cloudflareddns.registry | string | `""` | The registry where the Cloudflare DDNS container image is hosted. Default: `"docker.io"`. |
-| image.cloudflareddns.repository | string | `""` | The name of the repository that contains the Cloudflare DDNS container image used. Default: `"timothyjmiller/cloudflare-ddns"`. |
+| image.cloudflareddns.registry | string | `""` | The registry where the Cloudflare DDNS container image is hosted. Default: `"ghcr.io"`. |
+| image.cloudflareddns.repository | string | `""` | The name of the repository that contains the Cloudflare DDNS container image used. Default: `"irfanhakim-as/cloudflare-ddns"`. |
 | image.cloudflareddns.tag | string | `""` | The tag that specifies the version of the Cloudflare DDNS container image used. Default: `Chart appVersion`. |
 | imagePullSecrets | list | `[]` | Credentials used to securely authenticate and authorise the pulling of container images from private registries. |
 | replicaCount | string | `""` | The desired number of running replicas for Cloudflare DDNS. Default: `"1"`. |

--- a/mika/cloudflareddns/templates/deployment.yaml
+++ b/mika/cloudflareddns/templates/deployment.yaml
@@ -1,5 +1,5 @@
-{{- $cloudflareddns_registry := .Values.image.cloudflareddns.registry | default "docker.io" | toString }}
-{{- $cloudflareddns_repository := .Values.image.cloudflareddns.repository | default "timothyjmiller/cloudflare-ddns" | toString }}
+{{- $cloudflareddns_registry := .Values.image.cloudflareddns.registry | default "ghcr.io" | toString }}
+{{- $cloudflareddns_repository := .Values.image.cloudflareddns.repository | default "irfanhakim-as/cloudflare-ddns" | toString }}
 {{- $cloudflareddns_tag := .Values.image.cloudflareddns.tag | default .Chart.AppVersion | toString }}
 {{- $cloudflareddns_pullPolicy := .Values.image.cloudflareddns.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}

--- a/mika/cloudflareddns/values.yaml
+++ b/mika/cloudflareddns/values.yaml
@@ -9,13 +9,13 @@ replicaCount: ""
 # Container images used for Cloudflare DDNS.
 image:
   # Cloudflare DDNS container image configurations.
-  # Source: https://hub.docker.com/r/timothyjmiller/cloudflare-ddns
+  # Source: https://github.com/irfanhakim-as/cloudflare-ddns/pkgs/container/cloudflare-ddns
   cloudflareddns:
     # The registry where the Cloudflare DDNS container image is hosted.
-    # Default: "docker.io"
+    # Default: "ghcr.io"
     registry: ""
     # The name of the repository that contains the Cloudflare DDNS container image used.
-    # Default: "timothyjmiller/cloudflare-ddns"
+    # Default: "irfanhakim-as/cloudflare-ddns"
     repository: ""
     # The tag that specifies the version of the Cloudflare DDNS container image used.
     # Default: Chart appVersion


### PR DESCRIPTION
# Changes

- Replaced the broken upstream image with a patched fork as default - will return to upstream if it ever gets addressed at some point
- Bumped chart version

# Related issues/PRs

- https://github.com/timothymiller/cloudflare-ddns/pull/203