### PR TITLE
waktusolat/rizz: Support log rotation

### DIFF
--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to federated social network.
 type: application
-version: 0.2.5
+version: 0.3.0
 appVersion: "0.2.2-stable-r1"
 keywords:
   - "rss"

--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to federated social network.
 type: application
 version: 0.3.0
-appVersion: "0.2.2-stable-r1"
+appVersion: "0.3.0-stable-r1"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/README.md
+++ b/mika/rizz/README.md
@@ -259,6 +259,9 @@ A secure application access token is required for each configured account.
 | rizz.debug | string | `""` | Specifies whether Rizz should run in debug mode. Default: `"false"`. |
 | rizz.domain | string | `""` | The ingress domain name that hosts the Rizz server. Default: `"localhost"`. |
 | rizz.feed | list | `[]` | RSS feed configurations. Items: `.endpoint`, `.id`, `.enabled`. |
+| rizz.log.level | string | `""` | The verbosity level of the Rizz service logs. Default: `"info"`. |
+| rizz.log.maxFileSize | string | `""` | The maximum size of each log file in megabytes before it is rotated. Default: `"10"`. |
+| rizz.log.maxFiles | string | `""` | The number of backup log files to retain before older ones are removed. Default: `"3"`. |
 | rizz.organic | string | `""` | Specifies whether to enable posting in organic numbers. Default: `"true"`. |
 | rizz.post_limit | string | `""` | The limit number of posts to be scheduled for posting per run. Default: `"3"`. |
 | rizz.retry_post | string | `""` | Specifies whether to retry posting if the post fails to be sent. Default: `"true"`. |

--- a/mika/rizz/README.md
+++ b/mika/rizz/README.md
@@ -284,7 +284,7 @@ A secure application access token is required for each configured account.
 | service.type | string | `""` | The type of service used to expose Rizz services. Default: `"ClusterIP"`. |
 | storage.log.accessMode | string | `""` | The access mode defining how the log storage can be mounted. Default: `"ReadWriteMany"`. |
 | storage.log.enabled | bool | `false` | Specifies whether persistent storage should be provisioned for log storage. |
-| storage.log.mountPath | string | `""` | The path where the log storage should be mounted on the container. Default: `"/var/log/apache2"`. |
+| storage.log.mountPath | string | `""` | The path where the log storage should be mounted on the container. Default: `"/var/log/django"`. |
 | storage.log.storage | string | `""` | The default amount of persistent storage allocated for the log storage. Default: `"50Mi"`. |
 | storage.log.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the log storage. Default: `"longhorn"`. |
 | storage.log.subPath | string | `""` | The subpath within the log storage to mount to the container. Leave empty if not required. |

--- a/mika/rizz/templates/configmap.yaml
+++ b/mika/rizz/templates/configmap.yaml
@@ -15,7 +15,6 @@
 {{- $domain := .Values.rizz.domain | toString }}
 {{- $domain = ternary $domain "localhost" (and $ingress (ne $domain "") (ne $domain "localhost")) }}
 {{- $serverAdmin := .Values.rizz.serverAdmin | default "admin@example.com" | toString }}
-{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/apache2" | toString }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -48,7 +47,7 @@ metadata:
     {{- include "rizz.labels" . | nindent 4 }}
 data:
   site-config.conf: |-
-    {{- include "rizz.site-config-conf" . | toString | replace "DOMAIN" $domain | replace "SERVER_ADMIN" $serverAdmin | replace "LOG_MOUNT_PATH" $logMountPath | nindent 4 }}
+    {{- include "rizz.site-config-conf" . | toString | replace "DOMAIN" $domain | replace "SERVER_ADMIN" $serverAdmin | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/mika/rizz/templates/configmap.yaml
+++ b/mika/rizz/templates/configmap.yaml
@@ -4,6 +4,9 @@
 {{- $debug := .Values.rizz.debug | default "false" | toString | quote }}
 {{- $scheduler_timezone := .Values.scheduler.timezone | default "Etc/UTC" | toString | quote }}
 {{- $visibility := .Values.rizz.visibility | default "public" | toString | quote }}
+{{- $logLevel := .Values.rizz.log.level | default "info" | toString | quote }}
+{{- $logMaxFiles := .Values.rizz.log.maxFiles | default "3" | toString | quote }}
+{{- $logMaxFileSize := .Values.rizz.log.maxFileSize | default "10" | toString | quote }}
 {{- $organic := .Values.rizz.organic | default "true" | toString | quote }}
 {{- $post_limit := .Values.rizz.post_limit | default "3" | toString | quote }}
 {{- $retry_post := .Values.rizz.retry_post | default "true" | toString | quote }}
@@ -26,6 +29,9 @@ data:
   ORGANIC_POSTS: {{ $organic }}
   POST_LIMIT: {{ $post_limit }}
   RETRY_POST: {{ $retry_post }}
+  LOG_LEVEL: {{ $logLevel }}
+  LOG_MAX_BACKUP: {{ $logMaxFiles }}
+  LOG_MAX_SIZE: {{ $logMaxFileSize }}
   {{- if $celery }}
   CELERY_BROKER: {{ $redis_service }}
   CELERY_BACKEND: {{ $redis_service }}

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -25,7 +25,7 @@
 {{- $redis_pullPolicy := .Values.image.redis.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}
-{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/apache2" | toString | quote }}
+{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/django" | toString | quote }}
 {{- $logSubPath := .Values.storage.log.subPath | toString }}
 {{- $allowedHosts := .Values.rizz.allowedHosts | join "," | toString }}
 {{- $domain := .Values.rizz.domain | toString }}

--- a/mika/rizz/templates/site-config.conf.tpl
+++ b/mika/rizz/templates/site-config.conf.tpl
@@ -22,7 +22,7 @@ Apache site-config.conf template
         Require all granted
     </Directory>
 
-    ErrorLog LOG_MOUNT_PATH/apache.error.log
-    CustomLog LOG_MOUNT_PATH/apache.access.log combined
+    ErrorLog /var/log/apache2/error.log
+    CustomLog /var/log/apache2/access.log combined
 </VirtualHost>
 {{- end }}

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -356,7 +356,7 @@ storage:
     # accessMode: "ReadWriteOnce"
     accessMode: ""
     # The path where the log storage should be mounted on the container.
-    # Default: "/var/log/apache2"
+    # Default: "/var/log/django"
     # Example:
     # mountPath: "/log"
     mountPath: ""

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -86,6 +86,23 @@ rizz:
   # Example:
   # visibility: "unlisted"
   visibility: ""
+  # Log configurations.
+  log:
+    # The verbosity level of the Rizz service logs.
+    # Default: "info"
+    # Example:
+    # level: "debug"
+    level: ""
+    # The number of backup log files to retain before older ones are removed.
+    # Default: "3"
+    # Example:
+    # maxFiles: "0"
+    maxFiles: ""
+    # The maximum size of each log file in megabytes before it is rotated.
+    # Default: "10"
+    # Example:
+    # maxFileSize: "0"
+    maxFileSize: ""
   # A list of hosts that are allowed to access the Rizz service in addition to the default.
   # Default: "127.0.0.1,localhost,$serviceName,$(POD_IP),$domain"
   # Example:

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times to federated social network.
 type: application
-version: 0.4.6
+version: 0.5.0
 appVersion: "0.4.2-stable-r1"
 keywords:
   - "waktu solat"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times to federated social network.
 type: application
 version: 0.5.0
-appVersion: "0.4.2-stable-r1"
+appVersion: "0.5.0-stable-r1"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -276,7 +276,7 @@ A secure application access token is required for each configured account.
 | service.waktusolat.port | string | `""` | The WaktuSolat port on which the WaktuSolat server should listen for connections. Default: `"80"`. |
 | storage.log.accessMode | string | `""` | The access mode defining how the log storage can be mounted. Default: `"ReadWriteMany"`. |
 | storage.log.enabled | bool | `false` | Specifies whether persistent storage should be provisioned for log storage. |
-| storage.log.mountPath | string | `""` | The path where the log storage should be mounted on the container. Default: `"/var/log/apache2"`. |
+| storage.log.mountPath | string | `""` | The path where the log storage should be mounted on the container. Default: `"/var/log/django"`. |
 | storage.log.storage | string | `""` | The default amount of persistent storage allocated for the log storage. Default: `"50Mi"`. |
 | storage.log.storageClassName | string | `""` | The storage class name used for dynamically provisioning a persistent volume for the log storage. Default: `"longhorn"`. |
 | storage.log.subPath | string | `""` | The subpath within the log storage to mount to the container. Leave empty if not required. |

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -286,6 +286,9 @@ A secure application access token is required for each configured account.
 | waktusolat.domain | string | `""` | The ingress domain name that hosts the WaktuSolat server. Default: `"localhost"`. |
 | waktusolat.feed | list | `[]` | WaktuSolat feed configurations. Items: `.endpoint`, `.id`, `.enabled`. |
 | waktusolat.location | list | `[]` | The code of locations WaktuSolat should fetch and update prayer times for. Default: `"wlp-0"`. |
+| waktusolat.log.level | string | `""` | The verbosity level of the WaktuSolat service logs. Default: `"info"`. |
+| waktusolat.log.maxFileSize | string | `""` | The maximum size of each log file in megabytes before it is rotated. Default: `"10"`. |
+| waktusolat.log.maxFiles | string | `""` | The number of backup log files to retain before older ones are removed. Default: `"3"`. |
 | waktusolat.post_limit | string | `""` | The limit number of posts to be scheduled for posting per run. Default: `"0"` (Unlimited). |
 | waktusolat.retry_post | string | `""` | Specifies whether to retry posting if the post fails to be sent. Default: `"false"`. |
 | waktusolat.secret | string | `""` | A 50-character secret key used for secure session management and cryptographic operations within the WaktuSolat service. |

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -14,7 +14,6 @@
 {{- $domain := .Values.waktusolat.domain | toString }}
 {{- $domain = ternary $domain "localhost" (and $ingress (ne $domain "") (ne $domain "localhost")) }}
 {{- $serverAdmin := .Values.waktusolat.serverAdmin | default "admin@example.com" | toString }}
-{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/apache2" | toString }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -45,7 +44,7 @@ metadata:
     {{- include "waktusolat.labels" . | nindent 4 }}
 data:
   site-config.conf: |-
-    {{- include "waktusolat.site-config-conf" . | toString | replace "DOMAIN" $domain | replace "SERVER_ADMIN" $serverAdmin | replace "LOG_MOUNT_PATH" $logMountPath | nindent 4 }}
+    {{- include "waktusolat.site-config-conf" . | toString | replace "DOMAIN" $domain | replace "SERVER_ADMIN" $serverAdmin | nindent 4 }}
 {{- if $feeds }}
 ---
 apiVersion: v1

--- a/mika/waktusolat/templates/configmap.yaml
+++ b/mika/waktusolat/templates/configmap.yaml
@@ -6,6 +6,9 @@
 {{- $scheduler_timezone := .Values.scheduler.timezone | default "Etc/UTC" | toString | quote }}
 {{- $visibility := .Values.waktusolat.visibility | default "public" | toString | quote }}
 {{- $location := .Values.waktusolat.location | default "wlp-0" | join "," | toString | quote }}
+{{- $logLevel := .Values.waktusolat.log.level | default "info" | toString | quote }}
+{{- $logMaxFiles := .Values.waktusolat.log.maxFiles | default "3" | toString | quote }}
+{{- $logMaxFileSize := .Values.waktusolat.log.maxFileSize | default "10" | toString | quote }}
 {{- $organic := .Values.waktusolat.organic | default "true" | toString | quote }}
 {{- $post_limit := .Values.waktusolat.post_limit | default "0" | toString | quote }}
 {{- $retry_post := .Values.waktusolat.retry_post | default "true" | toString | quote }}
@@ -28,6 +31,9 @@ data:
   ORGANIC_POSTS: {{ $organic }}
   POST_LIMIT: {{ $post_limit }}
   RETRY_POST: {{ $retry_post }}
+  LOG_LEVEL: {{ $logLevel }}
+  LOG_MAX_BACKUP: {{ $logMaxFiles }}
+  LOG_MAX_SIZE: {{ $logMaxFileSize }}
   {{- if $celery }}
   CELERY_BROKER: {{ $redis_service }}
   CELERY_BACKEND: {{ $redis_service }}

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -26,7 +26,7 @@
 {{- $redis_pullPolicy := .Values.image.redis.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}
-{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/apache2" | toString | quote }}
+{{- $logMountPath := .Values.storage.log.mountPath | default "/var/log/django" | toString | quote }}
 {{- $logSubPath := .Values.storage.log.subPath | toString }}
 {{- $allowedHosts := .Values.waktusolat.allowedHosts | join "," | toString }}
 {{- $domain := .Values.waktusolat.domain | toString }}

--- a/mika/waktusolat/templates/site-config-conf.tpl
+++ b/mika/waktusolat/templates/site-config-conf.tpl
@@ -22,7 +22,7 @@ Apache site-config.conf template
         Require all granted
     </Directory>
 
-    ErrorLog LOG_MOUNT_PATH/apache.error.log
-    CustomLog LOG_MOUNT_PATH/apache.access.log combined
+    ErrorLog /var/log/apache2/error.log
+    CustomLog /var/log/apache2/access.log combined
 </VirtualHost>
 {{- end }}

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -375,7 +375,7 @@ storage:
     # accessMode: "ReadWriteOnce"
     accessMode: ""
     # The path where the log storage should be mounted on the container.
-    # Default: "/var/log/apache2"
+    # Default: "/var/log/django"
     # Example:
     # mountPath: "/log"
     mountPath: ""

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -81,6 +81,23 @@ waktusolat:
   # Example:
   # visibility: "unlisted"
   visibility: ""
+  # Log configurations.
+  log:
+    # The verbosity level of the WaktuSolat service logs.
+    # Default: "info"
+    # Example:
+    # level: "debug"
+    level: ""
+    # The number of backup log files to retain before older ones are removed.
+    # Default: "3"
+    # Example:
+    # maxFiles: "0"
+    maxFiles: ""
+    # The maximum size of each log file in megabytes before it is rotated.
+    # Default: "10"
+    # Example:
+    # maxFileSize: "0"
+    maxFileSize: ""
   # A list of hosts that are allowed to access the WaktuSolat service in addition to the default.
   # Default: "127.0.0.1,localhost,$serviceName,$(POD_IP),$domain"
   # Example:


### PR DESCRIPTION
# Changes

- Updated default `storage.log.mountPath` value, since app log dir and webserver (apache) log dir are now separate/differentiated
- Updated apache webserver log dir path to a hardcoded value rather than what is configured by the user - since that now corresponds to the path to the app log
- Added new `log` configuration options in chart values - can be used to configure log rotation
- Upgraded chart and app versions

# Related issues/PRs

- https://github.com/irfanhakim-as/waktusolat/pull/20
- https://github.com/irfanhakim-as/rizz/pull/21