### PR TITLE
vaultwarden: Upgrade to latest 1.35.0 version

### DIFF
--- a/mika/vaultwarden/Chart.yaml
+++ b/mika/vaultwarden/Chart.yaml
@@ -3,7 +3,7 @@ name: vaultwarden
 description: An alternative server implementation of the Bitwarden Client API written in Rust and compatible with official Bitwarden clients.
 type: application
 version: 0.1.0
-appVersion: "1.33.2"
+appVersion: "1.35.0-alpine"
 keywords:
   - "vaultwarden"
   - "bitwarden"

--- a/mika/vaultwarden/Chart.yaml
+++ b/mika/vaultwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vaultwarden
 description: An alternative server implementation of the Bitwarden Client API written in Rust and compatible with official Bitwarden clients.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.35.0-alpine"
 keywords:
   - "vaultwarden"

--- a/mika/vaultwarden/values.yaml
+++ b/mika/vaultwarden/values.yaml
@@ -91,7 +91,7 @@ vaultwarden:
   # send: "false"
   send: ""
   # A list of experimental client feature flags to enable certain experimental functionality.
-  # Note: Please refer to https://github.com/dani-garcia/vaultwarden/blob/main/.env.template#L348 for the full list of options.
+  # Note: Please refer to https://github.com/dani-garcia/vaultwarden/blob/main/.env.template#L369 for the full list of options.
   # Example:
   # expFeatures:
   #   - "autofill-v2"


### PR DESCRIPTION
# Changes

- Upgraded default app version from `1.33.2` to `1.35.0-alpine`: This fixes some incompatibility issues with newer Bitwarden clients
- Updated link to experimental features reference
- Bumped chart version to 0.1.1