### PR TITLE
rizz/waktusolat: Upgrade app

### DIFF
--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -3,7 +3,7 @@ name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to federated social network.
 type: application
 version: 0.3.0
-appVersion: "0.3.0-stable-r1"
+appVersion: "0.4.0-stable-r1"
 keywords:
   - "rss"
   - "monitor"

--- a/mika/rizz/Chart.yaml
+++ b/mika/rizz/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rizz
 description: Rizz is a simple web application that tracks and posts content from RSS Feeds to federated social network.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.4.0-stable-r1"
 keywords:
   - "rss"

--- a/mika/rizz/README.md
+++ b/mika/rizz/README.md
@@ -229,7 +229,7 @@ A secure application access token is required for each configured account.
 | image.redis.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Redis container image. Default: `"IfNotPresent"`. |
 | image.redis.registry | string | `""` | The registry where the Redis container image is hosted. Default: `"docker.io"`. |
 | image.redis.repository | string | `""` | The name of the repository that contains the Redis container image used. Default: `"redis"`. |
-| image.redis.tag | string | `""` | The tag that specifies the version of the Redis container image used. Default: `"alpine"`. |
+| image.redis.tag | string | `""` | The tag that specifies the version of the Redis container image used. Default: `"8.4.0-alpine3.22"`. |
 | image.rizz.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Rizz container image. Default: `"IfNotPresent"`. |
 | image.rizz.registry | string | `""` | The registry where the Rizz container image is hosted. Default: `"ghcr.io"`. |
 | image.rizz.repository | string | `""` | The name of the repository that contains the Rizz container image used. Default: `"irfanhakim-as/rizz"`. |

--- a/mika/rizz/templates/deployment.yaml
+++ b/mika/rizz/templates/deployment.yaml
@@ -21,7 +21,7 @@
 {{- $rizz_pullPolicy := .Values.image.rizz.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $redis_registry := .Values.image.redis.registry | default "docker.io" | toString }}
 {{- $redis_repository := .Values.image.redis.repository | default "redis" | toString }}
-{{- $redis_tag := .Values.image.redis.tag | default "alpine" | toString }}
+{{- $redis_tag := .Values.image.redis.tag | default "8.4.0-alpine3.22" | toString }}
 {{- $redis_pullPolicy := .Values.image.redis.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}

--- a/mika/rizz/values.yaml
+++ b/mika/rizz/values.yaml
@@ -33,7 +33,7 @@ image:
     # Default: "redis"
     repository: ""
     # The tag that specifies the version of the Redis container image used.
-    # Default: "alpine"
+    # Default: "8.4.0-alpine3.22"
     tag: ""
     # The policy that determines when Kubernetes should pull the Redis container image.
     # Default: "IfNotPresent"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times to federated social network.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.6.0-stable-r1"
 keywords:
   - "waktu solat"

--- a/mika/waktusolat/Chart.yaml
+++ b/mika/waktusolat/Chart.yaml
@@ -3,7 +3,7 @@ name: waktusolat
 description: Waktu Solat is a simple web application that posts local prayer times to federated social network.
 type: application
 version: 0.5.0
-appVersion: "0.5.0-stable-r1"
+appVersion: "0.6.0-stable-r1"
 keywords:
   - "waktu solat"
   - "prayer time"

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -229,7 +229,7 @@ A secure application access token is required for each configured account.
 | image.redis.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Redis container image. Default: `"alpine"`. |
 | image.redis.registry | string | `""` | The registry where the Redis container image is hosted. Default: `"docker.io"`. |
 | image.redis.repository | string | `""` | The name of the repository that contains the Redis container image used. Default: `"redis"`. |
-| image.redis.tag | string | `""` | The tag that specifies the version of the Redis container image used. Default: `"alpine"`. |
+| image.redis.tag | string | `""` | The tag that specifies the version of the Redis container image used. Default: `"8.4.0-alpine3.22"`. |
 | image.waktusolat.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the WaktuSolat container image. Default: `"IfNotPresent"`. |
 | image.waktusolat.registry | string | `""` | The registry where the WaktuSolat container image is hosted. Default: `"ghcr.io"`. |
 | image.waktusolat.repository | string | `""` | The name of the repository that contains the WaktuSolat container image used. Default: `"irfanhakim-as/waktusolat"`. |

--- a/mika/waktusolat/README.md
+++ b/mika/waktusolat/README.md
@@ -226,7 +226,7 @@ A secure application access token is required for each configured account.
 | db.port | string | `""` | The port number the WaktuSolat database server is listening for connections. Default: `"5432"`. |
 | db.type | string | `""` | The database engine or backend being used by WaktuSolat. Default: `"postgresql"`. |
 | db.user | string | `""` | The username or user account for accessing the WaktuSolat database. |
-| image.redis.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Redis container image. Default: `"alpine"`. |
+| image.redis.pullPolicy | string | `""` | The policy that determines when Kubernetes should pull the Redis container image. Default: `"IfNotPresent"`. |
 | image.redis.registry | string | `""` | The registry where the Redis container image is hosted. Default: `"docker.io"`. |
 | image.redis.repository | string | `""` | The name of the repository that contains the Redis container image used. Default: `"redis"`. |
 | image.redis.tag | string | `""` | The tag that specifies the version of the Redis container image used. Default: `"8.4.0-alpine3.22"`. |

--- a/mika/waktusolat/templates/deployment.yaml
+++ b/mika/waktusolat/templates/deployment.yaml
@@ -22,7 +22,7 @@
 {{- $waktusolat_pullPolicy := .Values.image.waktusolat.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $redis_registry := .Values.image.redis.registry | default "docker.io" | toString }}
 {{- $redis_repository := .Values.image.redis.repository | default "redis" | toString }}
-{{- $redis_tag := .Values.image.redis.tag | default "alpine" | toString }}
+{{- $redis_tag := .Values.image.redis.tag | default "8.4.0-alpine3.22" | toString }}
 {{- $redis_pullPolicy := .Values.image.redis.pullPolicy | default "IfNotPresent" | toString | quote }}
 {{- $release_name := .Release.Name | toString }}
 {{- $replica_count := .Values.replicaCount | default "1" | toString }}

--- a/mika/waktusolat/values.yaml
+++ b/mika/waktusolat/values.yaml
@@ -33,7 +33,7 @@ image:
     # Default: "redis"
     repository: ""
     # The tag that specifies the version of the Redis container image used.
-    # Default: "alpine"
+    # Default: "8.4.0-alpine3.22"
     tag: ""
     # The policy that determines when Kubernetes should pull the Redis container image.
     # Default: "IfNotPresent"


### PR DESCRIPTION
# Changes

- rizz: Upgraded default app version to `0.4.0-stable-r1` which includes security vulnerability fixes
- waktusolat: Upgraded default app version to `0.6.0-stable-r1` which includes security vulnerability fixes
- Pinned redis to version `8.4.0-alpine3.22`
- waktusolat: Minor fix to docs
- Bumped chart versions

# Related issues/PRs

- https://git.moekai.net/irfan/rizz/pulls/1
- https://git.moekai.net/irfan/waktusolat/pulls/1