### PR TITLE
external-svc: Replace deprecated Endpoints with EndpointSlices

### DIFF
--- a/mika/external-svc/Chart.yaml
+++ b/mika/external-svc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: external-svc
 description: Seamlessly connect external services to your Kubernetes environment.
 type: application
-version: 0.1.1
+version: 0.2.0
 keywords:
   - "external-svc"
   - "external"

--- a/mika/external-svc/README.md
+++ b/mika/external-svc/README.md
@@ -128,6 +128,6 @@ Seamlessly connect external services to your Kubernetes environment.
 |-----|------|---------|-------------|
 | ingress.clusterIssuer | string | `""` | The name of the cluster issuer for Ingress. Default: `"letsencrypt-dns-prod"`. |
 | ingress.customAnnotations | list | `[]` | Additional configuration annotations to be added to the Ingress resource of each external service. Items: `.prefix`, `.name`, `.value`. |
-| ingress.domains | list | `[]` | Domain configurations. Items: `.name`, `.port`, `.www`, `.customAnnotations`. |
+| ingress.domains | list | `[]` | Domain configurations. Items: `.name`, `.port`, `.tls`, `.www`, `.customAnnotations`. |
 | ingress.enabled | bool | `false` | Specifies whether Ingress should be enabled for hosting External Service services. |
 | services | list | `[]` | Service configurations. Items: `.host`, `.name`, `.nodePort`, `.port`, `.targetPort`, `.type`. |

--- a/mika/external-svc/templates/NOTES.txt
+++ b/mika/external-svc/templates/NOTES.txt
@@ -35,6 +35,7 @@ The following are a list of domain(s) you have supplied for the external service
 {{- else }}
 
     {{- range $index, $domain := $domains }}
+        {{- $tls := (ne .tls false) | toString }}
         {{- $www := $domain.www | toString }}
         {{- $name := $domain.name | toString }}
         {{- $port := $domain.port | toString }}

--- a/mika/external-svc/templates/NOTES.txt
+++ b/mika/external-svc/templates/NOTES.txt
@@ -41,7 +41,7 @@ The following are a list of domain(s) you have supplied for the external service
         {{- $port := $domain.port | toString }}
         {{- $customAnnotations := ternary "true" "false" (not (empty $domain.customAnnotations)) | toString }}
 
-    {{ printf "%s. name=%s | domain=%s | www=%s | custom_annotations=%s" ($index | add1 | toString) $port $name $www $customAnnotations }}
+    {{ printf "%s. name=%s | domain=%s | tls=%s | www=%s | custom_annotations=%s" ($index | add1 | toString) $port $name $tls $www $customAnnotations }}
 
     {{- end }}
 

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -69,7 +69,7 @@ spec:
       {{- if $www }}
         - {{ $wwwDomain }}
       {{- end }}
-      secretName: {{ $releaseName }}-{{ $port }}-extsvc-tls-cert
+      secretName: {{ $releaseName }}-{{ $name | replace "." "-" }}-extsvc-tls-cert
   {{- end }}
 {{- end }}
 {{- end }}

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -62,6 +62,7 @@ spec:
             path: /
             pathType: Prefix
   {{- end }}
+  {{- if $tls }}
   tls:
     - hosts:
         - {{ $name | quote }}
@@ -69,5 +70,6 @@ spec:
         - {{ $wwwDomain }}
       {{- end }}
       secretName: {{ $releaseName }}-{{ $port }}-extsvc-tls-cert
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -7,6 +7,7 @@
 {{- if and $ingress $services $domains }}
 {{- range $domains }}
 {{- $customAnnotations := .customAnnotations }}
+{{- $tls := ne .tls false }}
 {{- $www := .www }}
 {{- $name := .name | toString }}
 {{- $port := .port | toString }}

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -20,8 +20,10 @@ metadata:
   labels:
     {{- include "external-svc.labels" $ | nindent 4 }}
   annotations:
+  {{- if $tls }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     cert-manager.io/private-key-algorithm: "ECDSA"
+  {{- end }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/affinity-mode: "persistent"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"

--- a/mika/external-svc/templates/ingress.yaml
+++ b/mika/external-svc/templates/ingress.yaml
@@ -16,7 +16,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $releaseName }}-{{ $port }}-extsvc-ingress
+  name: {{ $releaseName }}-{{ $name | replace "." "-" }}-extsvc-ingress
   labels:
     {{- include "external-svc.labels" $ | nindent 4 }}
   annotations:

--- a/mika/external-svc/templates/service.yaml
+++ b/mika/external-svc/templates/service.yaml
@@ -25,17 +25,19 @@ spec:
       protocol: TCP
       name: {{ $name }}
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
-  name: {{ $releaseName }}-{{ $name }}-extsvc-svc
+  name: {{ $releaseName }}-{{ $name }}-extsvc-svc-endpointslice
   labels:
+    kubernetes.io/service-name: {{ $releaseName }}-{{ $name }}-extsvc-svc
     {{- include "external-svc.labels" $ | nindent 4 }}
-subsets:
+addressType: IPv4
+endpoints:
   - addresses:
-    - ip: {{ $host }}
-    ports:
-      - name: {{ $name }}
-        port: {{ $targetPort }}
-        protocol: TCP
+    - {{ $host }}
+ports:
+  - name: {{ $name }}
+    port: {{ $targetPort }}
+    protocol: TCP
 {{- end }}

--- a/mika/external-svc/values.yaml
+++ b/mika/external-svc/values.yaml
@@ -64,7 +64,7 @@ ingress:
   #     value: ""
   customAnnotations: []
   # Domain configurations.
-  # Items: `.name`, `.port`, `.www`, `.customAnnotations`
+  # Items: `.name`, `.port`, `.tls`, `.www`, `.customAnnotations`
   # Example:
   # domains:
   #   # The ingress domain name that hosts the external service.
@@ -75,6 +75,11 @@ ingress:
   #   # Example:
   #   # port: "mysvc"
   #     port: ""
+  #   # Specifies whether to enable TLS/HTTPS with Let's Encrypt certificates.
+  #   # Default: true
+  #   # Example:
+  #   # tls: false
+  #     tls: true
   #   # Specifies whether the WWW subdomain should be enabled.
   #   # Example:
   #   # www: true


### PR DESCRIPTION
# Changes

- Endpoints resources have been deprecated, moved to using EndpointSlices instead
- Added new `tls` option to `ingress.domains` (default: `true`) - supports non-TLS domains now e.g. for local services
- Renamed ingress and cert generated per-domain to use the domain name as part of its name instead of the service port
- Bumped chart version to `0.2.0`